### PR TITLE
docs: シフト登録業務フロー図を追加

### DIFF
--- a/docs/shift_workflow.html
+++ b/docs/shift_workflow.html
@@ -776,14 +776,14 @@
                             <td style="padding: 6px; border: 2px solid #e2e8f0; background: #fafafa; width: 90px;"></td>
                             <td style="padding: 6px; border: 2px solid #e2e8f0; background: #fafafa; width: 90px;"></td>
                             <td rowspan="2" style="padding: 8px; border: 2px solid #e2e8f0; vertical-align: middle; width: 280px;">
+                                <p style="margin-bottom: 10px; color: #dc2626; font-weight: 600; font-size: 0.8em;">
+                                    ⚠️ UIレベルの制約のみ（API制約なし）
+                                </p>
                                 <ul style="margin: 0; padding-left: 15px; line-height: 1.6; font-size: 0.85em;">
                                     <li>編集・削除・追加すべて可能</li>
                                     <li>プラン全体の削除可能</li>
                                     <li>過去月のプラン削除は不可</li>
                                 </ul>
-                                <p style="margin-top: 8px; color: #dc2626; font-weight: 600; font-size: 0.8em;">
-                                    ⚠️ UIレベルの制約のみ（API制約なし）
-                                </p>
                             </td>
                         </tr>
                         <tr>
@@ -870,15 +870,15 @@
                             </td>
                             <td style="padding: 6px; border: 2px solid #e2e8f0; background: #fafafa; width: 90px;"></td>
                             <td rowspan="2" style="padding: 8px; border: 2px solid #e2e8f0; vertical-align: middle; width: 280px;">
+                                <p style="margin-bottom: 10px; color: #dc2626; font-weight: 600; font-size: 0.8em;">
+                                    ⚠️ UIレベルの制約のみ（API制約なし）
+                                </p>
                                 <ul style="margin: 0; padding-left: 15px; line-height: 1.6; font-size: 0.85em;">
                                     <li>編集・削除・追加すべて可能</li>
                                     <li>第1案がAPPROVED必須</li>
                                     <li>希望照合機能あり</li>
                                     <li>AI修正アシスタント利用可能</li>
                                 </ul>
-                                <p style="margin-top: 8px; color: #dc2626; font-weight: 600; font-size: 0.8em;">
-                                    ⚠️ UIレベルの制約のみ（API制約なし）
-                                </p>
                             </td>
                         </tr>
                         <tr>
@@ -934,15 +934,15 @@
                                 <p style="margin-bottom: 10px; color: #dc2626; font-weight: 600; font-size: 0.8em;">
                                     ⚠️ 基本的に公開後のシフト変更は推奨しない
                                 </p>
+                                <p style="margin-bottom: 10px; color: #dc2626; font-weight: 600; font-size: 0.8em;">
+                                    ⚠️ UIレベルの制約のみ（API制約なし）
+                                </p>
                                 <ul style="margin: 0; padding-left: 15px; line-height: 1.6; font-size: 0.85em;">
                                     <li>編集・削除・追加すべて可能</li>
                                     <li>第1案がAPPROVED必須</li>
                                     <li>希望照合機能あり</li>
                                     <li>AI修正アシスタント利用可能</li>
                                 </ul>
-                                <p style="margin-top: 8px; color: #dc2626; font-weight: 600; font-size: 0.8em;">
-                                    ⚠️ UIレベルの制約のみ（API制約なし）
-                                </p>
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
- フェーズ・ステータス別のシフト変更方法フロー図を作成
- 業務フロー、ステータス遷移、シフト変更の3つのタブで構成
- 従業員側と店側の操作フローを視覚的に表示
- 各フェーズの制約事項を明記

#2 の対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)