### PR TITLE
fix: lint-stagedのパス解決問題を修正

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,9 +1,13 @@
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default {
   'frontend/**/*.{js,jsx}': (filenames) => {
+    const frontendDir = path.join(__dirname, 'frontend')
     const frontendFiles = filenames.map(f => {
-      const relative = path.relative('frontend', f)
+      const relative = path.relative(frontendDir, f)
       return `"${relative}"`
     })
     return [


### PR DESCRIPTION
問題:
- path.relative('frontend', f) が相対パス文字列を使用していたため、 ワーキングディレクトリによってパス解決が不安定だった
- その結果、pre-commit時にprettierが一部のファイルに適用されないことがあった

修正内容:
- import.meta.url を使用してスクリプトの絶対パスを取得
- fileURLToPath と path.dirname で __dirname 相当を構築
- path.join(__dirname, 'frontend') で frontendディレクトリの絶対パスを取得
- 絶対パスベースで path.relative を実行し、確実にパス解決

これにより、どのディレクトリから実行されても、
pre-commit時に正しくlint/prettierが適用されるようになる

#72 

🤖 Generated with [Claude Code](https://claude.com/claude-code)