### PR TITLE
debug: Add BACKEND_API_URL and health response logging

### DIFF
--- a/frontend/src/components/shared/AppHeader.jsx
+++ b/frontend/src/components/shared/AppHeader.jsx
@@ -41,8 +41,10 @@ const AppHeader = () => {
   useEffect(() => {
     const fetchHealthInfo = async () => {
       try {
+        console.log('🔍 BACKEND_API_URL:', BACKEND_API_URL)
         const response = await fetch(`${BACKEND_API_URL}/api/health`)
         const data = await response.json()
+        console.log('🔍 Health Response:', data)
 
         if (data.success) {
           setBackendEnv(data.backend.environment)


### PR DESCRIPTION
## Summary
デバッグ用に BACKEND_API_URL と health API レスポンスのログを追加

## Changes
- AppHeader.jsx に以下のログを追加:
  - `BACKEND_API_URL` の値
  - `/api/health` のレスポンス内容

## Purpose
STG環境でフロントエンドがどのバックエンドURLに接続しているかを確認するため

🤖 Generated with [Claude Code](https://claude.com/claude-code)