### PR TITLE
fix: Tempシフト削除時の500エラーを修正

### DIFF
--- a/docs/design-docs/temp_shift_deletion_fix.html
+++ b/docs/design-docs/temp_shift_deletion_fix.html
@@ -1,0 +1,409 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tempシフト削除エラー修正 - 設計書</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            line-height: 1.6;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        .container {
+            background: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #2c3e50;
+            border-bottom: 3px solid #3498db;
+            padding-bottom: 10px;
+        }
+        h2 {
+            color: #34495e;
+            margin-top: 30px;
+            border-left: 4px solid #3498db;
+            padding-left: 10px;
+        }
+        h3 {
+            color: #7f8c8d;
+        }
+        .metadata {
+            background: #ecf0f1;
+            padding: 15px;
+            border-radius: 5px;
+            margin-bottom: 20px;
+        }
+        .metadata p {
+            margin: 5px 0;
+        }
+        .problem {
+            background: #ffe6e6;
+            border-left: 4px solid #e74c3c;
+            padding: 15px;
+            margin: 15px 0;
+        }
+        .solution {
+            background: #e8f8f5;
+            border-left: 4px solid #27ae60;
+            padding: 15px;
+            margin: 15px 0;
+        }
+        code {
+            background: #f4f4f4;
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-family: 'Courier New', monospace;
+        }
+        pre {
+            background: #2c3e50;
+            color: #ecf0f1;
+            padding: 15px;
+            border-radius: 5px;
+            overflow-x: auto;
+        }
+        pre code {
+            background: none;
+            color: #ecf0f1;
+        }
+        .flow-diagram {
+            background: #f9f9f9;
+            border: 2px solid #ddd;
+            padding: 20px;
+            margin: 20px 0;
+            border-radius: 5px;
+        }
+        .step {
+            margin: 10px 0;
+            padding: 10px;
+            background: white;
+            border-left: 3px solid #3498db;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 20px 0;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 12px;
+            text-align: left;
+        }
+        th {
+            background: #3498db;
+            color: white;
+        }
+        tr:nth-child(even) {
+            background: #f9f9f9;
+        }
+        .tag {
+            display: inline-block;
+            padding: 3px 8px;
+            border-radius: 3px;
+            font-size: 0.85em;
+            margin: 2px;
+        }
+        .tag-bug { background: #e74c3c; color: white; }
+        .tag-frontend { background: #3498db; color: white; }
+        .tag-high { background: #e67e22; color: white; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Tempシフト削除エラー修正 - 設計書</h1>
+
+        <div class="metadata">
+            <p><strong>作成日:</strong> 2025-11-25</p>
+            <p><strong>対象バージョン:</strong> v1.0</p>
+            <p><strong>関連Issue:</strong> Temp shift deletion 500 error</p>
+            <p><strong>優先度:</strong> <span class="tag tag-high">高</span></p>
+            <p><strong>対象範囲:</strong> <span class="tag tag-frontend">フロントエンド</span></p>
+            <p><strong>影響コンポーネント:</strong> SecondPlanEditor, FirstPlanEditor</p>
+        </div>
+
+        <h2>1. 問題の概要</h2>
+        <div class="problem">
+            <h3>発生している問題</h3>
+            <p>ユーザーが第2案（または第1案）シフト編集画面で以下の操作を行うと、500 エラーが発生する：</p>
+            <ol>
+                <li>新規シフトを追加（temp ID が割り当てられる）</li>
+                <li>追加したシフトに間違いがあることに気づく</li>
+                <li>下書き保存前にそのシフトを削除</li>
+                <li>「下書き保存」ボタンをクリック</li>
+                <li><strong>→ シフト削除エラー: HTTP error! status: 500</strong></li>
+            </ol>
+        </div>
+
+        <div class="problem">
+            <h3>エラーログ</h3>
+            <pre><code>シフト削除エラー: Error: HTTP error! status: 500
+    at Ad.deleteShift (index-641nD0Oe.js:358:10200)
+    at async Promise.all (index 2)
+    at async qe (index-641nD0Oe.js:436:2459)</code></pre>
+        </div>
+
+        <h2>2. 根本原因分析</h2>
+
+        <h3>2.1 Tempシフトの設計</h3>
+        <p>新規シフト追加時、まだデータベースに保存されていないシフトには一時的な ID（temp ID）が割り当てられる：</p>
+        <pre><code>// SecondPlanEditor.jsx:1200
+const tempId = `temp_${Date.now()}_${Math.random()}`
+
+例: temp_1732521234567_0.8618827605271699</code></pre>
+
+        <p>Temp シフトは以下の3つの状態配列に追加される：</p>
+        <table>
+            <tr>
+                <th>配列名</th>
+                <th>用途</th>
+                <th>処理タイミング</th>
+            </tr>
+            <tr>
+                <td><code>addedShifts</code></td>
+                <td>バックエンドに送信する新規シフトリスト</td>
+                <td>下書き保存時に CREATE API を呼ぶ</td>
+            </tr>
+            <tr>
+                <td><code>csvShifts</code></td>
+                <td>カレンダー表示用メイン配列</td>
+                <td>UI レンダリング</td>
+            </tr>
+            <tr>
+                <td><code>dayShifts</code></td>
+                <td>日別ビュー用配列</td>
+                <td>日別ビューレンダリング</td>
+            </tr>
+        </table>
+
+        <h3>2.2 削除処理の問題点</h3>
+        <p><strong>現在のコード（SecondPlanEditor.jsx:1085）:</strong></p>
+        <pre><code>const handleDeleteShift = shiftId => {
+  setHasUnsavedChanges(true)
+
+  // 問題: temp ID も実 ID も区別せず削除リストに追加
+  setDeletedShiftIds(prev => new Set([...prev, shiftId]))
+
+  // UI から削除
+  setCsvShifts(prev => prev.filter(shift => shift.shift_id !== shiftId))
+  setDayShifts(prev => prev.filter(s => s.shift_id !== shiftId))
+}</code></pre>
+
+        <p><strong>下書き保存時の処理（SecondPlanEditor.jsx:1156-1159）:</strong></p>
+        <pre><code>// Delete shifts
+for (const shiftId of deletedShiftIds) {
+  console.log('シフト削除:', shiftId)
+  // 問題: temp ID に対しても DELETE API を呼んでしまう
+  updatePromises.push(shiftRepository.deleteShift(shiftId))
+}</code></pre>
+
+        <h3>2.3 エラー発生フロー</h3>
+        <div class="flow-diagram">
+            <div class="step">
+                <strong>Step 1:</strong> ユーザーが新規シフト追加 → <code>temp_1732521234567_0.123456</code> が作成される
+            </div>
+            <div class="step">
+                <strong>Step 2:</strong> <code>addedShifts</code>, <code>csvShifts</code>, <code>dayShifts</code> に追加
+            </div>
+            <div class="step">
+                <strong>Step 3:</strong> ユーザーがそのシフトを削除 → <code>temp_...</code> が <code>deletedShiftIds</code> に追加
+            </div>
+            <div class="step">
+                <strong>Step 4:</strong> 下書き保存ボタンクリック → <code>handleSaveDraft()</code> 実行
+            </div>
+            <div class="step">
+                <strong>Step 5:</strong> <code>shiftRepository.deleteShift("temp_...")</code> 実行
+            </div>
+            <div class="step">
+                <strong>Step 6:</strong> バックエンド DELETE /api/shifts/temp_... → <strong>404 または 500 エラー</strong>
+            </div>
+            <div class="step">
+                <strong>原因:</strong> temp ID はデータベースに存在しないため、削除できない
+            </div>
+        </div>
+
+        <h2>3. 解決策</h2>
+
+        <div class="solution">
+            <h3>設計方針</h3>
+            <p><code>handleDeleteShift</code> 関数内で、削除対象シフトが temp ID か実 ID かを判定し、処理を分岐させる：</p>
+            <ul>
+                <li><strong>Temp ID の場合:</strong> フロントエンドの <code>addedShifts</code> から削除するだけ（バックエンド API 不要）</li>
+                <li><strong>実 ID の場合:</strong> <code>deletedShiftIds</code> に追加してバックエンド DELETE API を呼ぶ</li>
+            </ul>
+        </div>
+
+        <h3>3.1 修正コード</h3>
+
+        <h4>SecondPlanEditor.jsx (Line 1085)</h4>
+        <pre><code>const handleDeleteShift = shiftId => {
+  setHasUnsavedChanges(true)
+
+  // Temp シフトかどうかを判定
+  if (String(shiftId).startsWith('temp_')) {
+    // Temp シフト: addedShifts から削除するだけ（バックエンド呼ばない）
+    setAddedShifts(prev => prev.filter(shift => shift.shift_id !== shiftId))
+  } else {
+    // 実シフト: deletedShiftIds に追加（バックエンドで削除）
+    setDeletedShiftIds(prev => new Set([...prev, shiftId]))
+  }
+
+  // UI からは両方削除
+  setCsvShifts(prev => prev.filter(shift => shift.shift_id !== shiftId))
+
+  if (selectedDate) {
+    const updatedShifts = dayShifts.filter(s => s.shift_id !== shiftId)
+    setDayShifts(updatedShifts)
+    if (updatedShifts.length === 0) {
+      closeDayView()
+    }
+  }
+}</code></pre>
+
+        <h4>FirstPlanEditor.jsx (Line 407)</h4>
+        <p>同様の修正を適用（コードは SecondPlanEditor と同じロジック）</p>
+
+        <h3>3.2 修正後のフロー</h3>
+        <div class="flow-diagram">
+            <div class="step">
+                <strong>Step 1:</strong> ユーザーが新規シフト追加 → <code>temp_1732521234567_0.123456</code> が作成
+            </div>
+            <div class="step">
+                <strong>Step 2:</strong> <code>addedShifts</code>, <code>csvShifts</code>, <code>dayShifts</code> に追加
+            </div>
+            <div class="step">
+                <strong>Step 3:</strong> ユーザーがそのシフトを削除 → <strong>temp ID を検出</strong>
+            </div>
+            <div class="step">
+                <strong>Step 4:</strong> <code>addedShifts</code> から削除 + UI から削除（<code>deletedShiftIds</code> には追加しない）
+            </div>
+            <div class="step">
+                <strong>Step 5:</strong> 下書き保存ボタンクリック → <code>handleSaveDraft()</code> 実行
+            </div>
+            <div class="step">
+                <strong>Step 6:</strong> <code>deletedShiftIds</code> が空なので、DELETE API は呼ばれない → <strong>エラーなし ✅</strong>
+            </div>
+        </div>
+
+        <h2>4. 影響範囲</h2>
+
+        <table>
+            <tr>
+                <th>ファイル</th>
+                <th>変更箇所</th>
+                <th>影響</th>
+            </tr>
+            <tr>
+                <td>frontend/src/components/screens/shift/SecondPlanEditor.jsx</td>
+                <td>handleDeleteShift (Line 1085)</td>
+                <td>第2案シフト削除処理</td>
+            </tr>
+            <tr>
+                <td>frontend/src/components/screens/shift/FirstPlanEditor.jsx</td>
+                <td>handleDeleteShift (Line 407)</td>
+                <td>第1案シフト削除処理</td>
+            </tr>
+        </table>
+
+        <h3>後方互換性</h3>
+        <ul>
+            <li>✅ 実 ID（データベース由来）の削除処理は変更なし</li>
+            <li>✅ temp ID 判定ロジックは新規追加なので、既存機能に影響なし</li>
+            <li>✅ UI の動作は変更なし（削除ボタンの挙動は同じ）</li>
+        </ul>
+
+        <h2>5. テスト計画</h2>
+
+        <h3>5.1 テストケース</h3>
+        <table>
+            <tr>
+                <th>テストケース</th>
+                <th>操作</th>
+                <th>期待結果</th>
+            </tr>
+            <tr>
+                <td>TC1: Temp シフト削除</td>
+                <td>
+                    1. 新規シフト追加<br>
+                    2. すぐに削除<br>
+                    3. 下書き保存
+                </td>
+                <td>エラーなく保存完了</td>
+            </tr>
+            <tr>
+                <td>TC2: 実シフト削除</td>
+                <td>
+                    1. 既存シフト（DB保存済み）を削除<br>
+                    2. 下書き保存
+                </td>
+                <td>バックエンド DELETE API が呼ばれ、DB から削除される</td>
+            </tr>
+            <tr>
+                <td>TC3: 混在</td>
+                <td>
+                    1. 新規シフト2件追加<br>
+                    2. 1件削除（temp）<br>
+                    3. 既存シフト1件削除（実ID）<br>
+                    4. 下書き保存
+                </td>
+                <td>
+                    - 新規シフト1件が CREATE される<br>
+                    - 実シフト1件が DELETE される<br>
+                    - エラーなし
+                </td>
+            </tr>
+        </table>
+
+        <h3>5.2 テスト環境</h3>
+        <ul>
+            <li><strong>ローカル環境:</strong> 開発サーバーで動作確認</li>
+            <li><strong>STG環境:</strong> Vercel Preview デプロイで実データを使用してテスト</li>
+        </ul>
+
+        <h2>6. デプロイ手順</h2>
+
+        <ol>
+            <li>修正をローカルで実装・テスト</li>
+            <li>コミット・プッシュ</li>
+            <li>PR 作成（<code>staging</code> ブランチへ）</li>
+            <li>CI/CD チェック通過確認</li>
+            <li>STG 環境で動作確認</li>
+            <li>PR マージ</li>
+            <li>本番リリース（<code>main</code> へマージ）</li>
+        </ol>
+
+        <h2>7. ロールバック計画</h2>
+
+        <p>修正が問題を引き起こした場合、以下の手順でロールバック：</p>
+        <ol>
+            <li>Git で前回のコミットに revert</li>
+            <li>再デプロイ</li>
+        </ol>
+        <p><strong>ロールバック時の影響:</strong> Temp シフト削除時の 500 エラーが再発する</p>
+
+        <h2>8. 補足事項</h2>
+
+        <h3>将来の改善案</h3>
+        <ul>
+            <li>Temp ID のフォーマットを厳密に定義（TypeScript 型定義）</li>
+            <li>シフト状態管理をより明確にする（draft / saved / modified の状態フラグ）</li>
+            <li>ユニットテストの追加（temp ID 判定ロジック）</li>
+        </ul>
+
+        <h3>関連ドキュメント</h3>
+        <ul>
+            <li><a href="./ARCHITECTURE.md">アーキテクチャドキュメント</a></li>
+            <li><a href="./STAGING_ENVIRONMENT_DESIGN.html">ステージング環境設計</a></li>
+        </ul>
+
+        <hr style="margin-top: 40px;">
+        <p style="text-align: center; color: #7f8c8d;">
+            <small>© 2025 Shift Scheduler AI - Generated with Claude Code</small>
+        </p>
+    </div>
+</body>
+</html>

--- a/frontend/src/components/screens/shift/FirstPlanEditor.jsx
+++ b/frontend/src/components/screens/shift/FirstPlanEditor.jsx
@@ -600,15 +600,6 @@ const FirstPlanEditor = ({
 
   // シフト更新ハンドラー（ローカルステートのみ更新）
   const handleUpdateShift = (shiftId, updates) => {
-    console.log('=== handleUpdateShift START ===')
-    console.log('shiftId:', shiftId)
-    console.log('updates:', updates)
-    console.log('selectedShift status:', selectedShift?.status)
-    console.log('current shiftData length:', shiftData.length)
-    console.log(
-      'current calendarData:',
-      calendarData ? Object.keys(calendarData.shiftsByDate).length + ' days' : 'null'
-    )
     setHasUnsavedChanges(true)
 
     // ローカルの変更を保持
@@ -659,17 +650,20 @@ const FirstPlanEditor = ({
         )
       )
     }
-
-    console.log('=== handleUpdateShift END ===')
-    console.log('Updated successfully for shiftId:', shiftId)
   }
 
   // シフト削除ハンドラー（ローカルステートのみ更新）
   const handleDeleteShift = shiftId => {
     setHasUnsavedChanges(true)
 
-    // ローカルの削除リストに追加
-    setDeletedShiftIds(prev => new Set([...prev, shiftId]))
+    // Tempシフト（未保存）かどうかを判定
+    if (String(shiftId).startsWith('temp_')) {
+      // Tempシフトの場合：addedShiftsから削除（バックエンドへの削除リクエストは不要）
+      setAddedShifts(prev => prev.filter(shift => shift.shift_id !== shiftId))
+    } else {
+      // 既存シフト（DB保存済み）の場合：削除リストに追加（バックエンドで削除）
+      setDeletedShiftIds(prev => new Set([...prev, shiftId]))
+    }
 
     // UIから削除
     setCalendarData(prev => {
@@ -702,8 +696,6 @@ const FirstPlanEditor = ({
 
   // シフト追加ハンドラー（ローカルステートのみ更新）
   const handleAddShift = newShiftData => {
-    console.log('=== handleAddShift START ===')
-    console.log('newShiftData:', newShiftData)
     setHasUnsavedChanges(true)
 
     // 一時的なシフトIDを生成
@@ -768,16 +760,10 @@ const FirstPlanEditor = ({
     if (selectedDay === day) {
       setDayShifts(prev => [...prev, newShift])
     }
-
-    console.log('=== handleAddShift END ===')
   }
 
   // セルクリック時のハンドラー
   const handleShiftClick = ({ mode, shift, date, staffId, storeId, event }) => {
-    console.log('=== handleShiftClick ===')
-    console.log('mode:', mode)
-    console.log('shift:', shift)
-
     // クリック位置を取得
     const rect = event?.target.getBoundingClientRect()
     const position = rect
@@ -832,10 +818,6 @@ const FirstPlanEditor = ({
 
   // モーダルからの保存処理
   const handleModalSave = timeData => {
-    console.log('=== handleModalSave ===')
-    console.log('modalState:', modalState)
-    console.log('timeData:', timeData)
-
     if (modalState.mode === 'add') {
       handleAddShift({
         ...modalState.shift,


### PR DESCRIPTION
## 問題

下書き保存前にTempシフト（未保存のシフト）を削除すると500エラーが発生していた。

## 原因

`handleDeleteShift` がTempシフトとDB保存済みシフトを区別せず、すべてのシフトIDを `deletedShiftIds` に追加していた。その結果、`handleSaveDraft` 時にDB未登録のTempシフトに対してもDELETE APIを呼び出してしまい、500エラーが発生していた。

## 修正内容

`handleDeleteShift` にTempシフト判定ロジックを追加:
- **Tempシフト** (`temp_`で始まるID): `addedShifts` から削除のみ（API呼び出しなし）
- **DB保存済みシフト**: `deletedShiftIds` に追加してDELETE API実行

## 修正ファイル

- `frontend/src/components/screens/shift/SecondPlanEditor.jsx:1079`
- `frontend/src/components/screens/shift/FirstPlanEditor.jsx:656`

## その他の変更

デバッグログの削除:
- `=== START/END ===` マーカー付きログを削除
- 詳細トレースログを削除（エラーログは保持）

## テスト方法

1. 第一案または第二案画面を開く
2. 新規シフトを追加（まだ下書き保存しない）
3. 追加したシフトを削除
4. 下書き保存を実行
5. エラーが出ないことを確認

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)