### PR TITLE
release: staging → main (テストツール追加)

### DIFF
--- a/scripts/tools/README.html
+++ b/scripts/tools/README.html
@@ -1,0 +1,454 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>テストツール使い方ガイド</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      line-height: 1.6;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #f5f5f5;
+      color: #333;
+    }
+    h1 {
+      color: #2c3e50;
+      border-bottom: 3px solid #3498db;
+      padding-bottom: 10px;
+    }
+    h2 {
+      color: #2980b9;
+      margin-top: 40px;
+      padding: 10px;
+      background: #ecf0f1;
+      border-radius: 5px;
+    }
+    h3 {
+      color: #27ae60;
+      margin-top: 25px;
+    }
+    .tool-card {
+      background: white;
+      border-radius: 8px;
+      padding: 20px;
+      margin: 20px 0;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    }
+    .tool-card h3 {
+      margin-top: 0;
+      color: #e74c3c;
+    }
+    code {
+      background: #2c3e50;
+      color: #ecf0f1;
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-family: 'Monaco', 'Consolas', monospace;
+      font-size: 0.9em;
+    }
+    pre {
+      background: #2c3e50;
+      color: #ecf0f1;
+      padding: 15px;
+      border-radius: 5px;
+      overflow-x: auto;
+      font-family: 'Monaco', 'Consolas', monospace;
+      font-size: 0.85em;
+    }
+    pre code {
+      background: none;
+      padding: 0;
+    }
+    .warning {
+      background: #fff3cd;
+      border-left: 4px solid #ffc107;
+      padding: 15px;
+      margin: 15px 0;
+      border-radius: 0 5px 5px 0;
+    }
+    .info {
+      background: #d1ecf1;
+      border-left: 4px solid #17a2b8;
+      padding: 15px;
+      margin: 15px 0;
+      border-radius: 0 5px 5px 0;
+    }
+    .success {
+      background: #d4edda;
+      border-left: 4px solid #28a745;
+      padding: 15px;
+      margin: 15px 0;
+      border-radius: 0 5px 5px 0;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 15px 0;
+      background: white;
+    }
+    th, td {
+      border: 1px solid #ddd;
+      padding: 10px;
+      text-align: left;
+    }
+    th {
+      background: #3498db;
+      color: white;
+    }
+    tr:nth-child(even) { background: #f9f9f9; }
+    .option { color: #9b59b6; font-weight: bold; }
+    .required { color: #e74c3c; }
+    .optional { color: #7f8c8d; }
+  </style>
+</head>
+<body>
+
+<h1>🛠️ シフトスケジューラー テストツール使い方ガイド</h1>
+
+<div class="info">
+  <strong>📁 保存場所:</strong> <code>scripts/tools/</code><br>
+  <strong>🔌 接続先:</strong> STG環境（Railway）<br>
+  <strong>🏢 対象テナント:</strong> tenant_id = 3
+</div>
+
+<h2>📋 ツール一覧</h2>
+
+<table>
+  <tr>
+    <th>ツール名</th>
+    <th>ファイル</th>
+    <th>用途</th>
+  </tr>
+  <tr>
+    <td>希望シフト生成</td>
+    <td><code>generate-random-preferences.mjs</code></td>
+    <td>スタッフの希望シフト（勤務希望/NG日）を生成</td>
+  </tr>
+  <tr>
+    <td>第1案生成</td>
+    <td><code>generate-first-plan.mjs</code></td>
+    <td>シフト第1案（FIRST Plan）を生成</td>
+  </tr>
+  <tr>
+    <td>実績シフト生成</td>
+    <td><code>generate-actual-shifts.mjs</code></td>
+    <td>第1案をベースに実績データを生成</td>
+  </tr>
+  <tr>
+    <td>スタッフ生成</td>
+    <td><code>generate-staff.mjs</code></td>
+    <td>ダミースタッフを生成・削除</td>
+  </tr>
+  <tr>
+    <td>データリセット</td>
+    <td><code>reset-data.mjs</code></td>
+    <td>テストデータを削除</td>
+  </tr>
+</table>
+
+<h2>🔒 ツール使用前の準備（重要）</h2>
+
+<div class="warning">
+  <strong>⚠️ 必ずバックアップを取ってから作業してください！</strong><br>
+  <code>--execute</code> や <code>--delete</code> を使う前に、DBのダンプを取得しておくと安心です。
+</div>
+
+<div class="tool-card">
+  <h3>📦 バックアップの取り方</h3>
+
+  <h4>1. PostgreSQLクライアントの準備（初回のみ）</h4>
+  <pre><code># macOS (Homebrew)
+arch -arm64 brew install postgresql@17
+
+# パスを通す
+export PATH="/opt/homebrew/opt/postgresql@17/bin:$PATH"</code></pre>
+
+  <h4>2. ダンプを取得</h4>
+  <pre><code># STG環境のダンプを取得
+PGPASSWORD=BWmHYBbEZqnptZRYmptockuomkHRWNPO pg_dump \
+  -h switchyard.proxy.rlwy.net \
+  -p 26491 \
+  -U postgres \
+  -d railway \
+  -F c \
+  -f backup_$(date +%Y%m%d_%H%M%S).dump
+
+# 確認
+ls -la backup_*.dump</code></pre>
+
+  <h4>3. リストア（元に戻す場合）</h4>
+  <pre><code># ダンプからリストア
+PGPASSWORD=BWmHYBbEZqnptZRYmptockuomkHRWNPO pg_restore \
+  -h switchyard.proxy.rlwy.net \
+  -p 26491 \
+  -U postgres \
+  -d railway \
+  --clean \
+  --if-exists \
+  backup_XXXXXXXX_XXXXXX.dump</code></pre>
+
+  <div class="info">
+    <strong>💡 ヒント:</strong> ダンプファイルは作業ディレクトリに保存されます。<br>
+    日付付きファイル名で複数のバックアップを管理できます。
+  </div>
+</div>
+
+<h2>⚙️ 共通オプション</h2>
+
+<table>
+  <tr>
+    <th>オプション</th>
+    <th>説明</th>
+  </tr>
+  <tr>
+    <td><code class="option">--dry-run</code></td>
+    <td>確認のみ（DBに書き込まない）<strong>デフォルト</strong></td>
+  </tr>
+  <tr>
+    <td><code class="option">--execute</code></td>
+    <td>実際にDBに書き込む</td>
+  </tr>
+  <tr>
+    <td><code class="option">--delete</code></td>
+    <td>指定条件のデータを削除</td>
+  </tr>
+  <tr>
+    <td><code class="option">--help</code></td>
+    <td>ヘルプを表示</td>
+  </tr>
+</table>
+
+<div class="warning">
+  <strong>⚠️ 注意:</strong> <code>--execute</code> や <code>--delete</code> を付けない限り、DBには何も書き込まれません。<br>
+  まずは <code>--dry-run</code>（デフォルト）で内容を確認してから実行してください。
+</div>
+
+<!-- ツール1: 希望シフト生成 -->
+<div class="tool-card">
+  <h3>① 希望シフト生成 (generate-random-preferences.mjs)</h3>
+
+  <p>スタッフの希望シフトをランダムに生成します。</p>
+  <ul>
+    <li><strong>社員:</strong> NG日（休み希望）を生成</li>
+    <li><strong>アルバイト:</strong> 勤務希望日＋時間を生成</li>
+  </ul>
+
+  <h4>基本的な使い方</h4>
+  <pre><code># 確認のみ（2025年1月分）
+node scripts/tools/generate-random-preferences.mjs --year 2025 --month 1
+
+# 実際に登録
+node scripts/tools/generate-random-preferences.mjs --year 2025 --month 1 --execute
+
+# 削除
+node scripts/tools/generate-random-preferences.mjs --year 2025 --month 1 --delete</code></pre>
+
+  <h4>オプション</h4>
+  <table>
+    <tr><th>オプション</th><th>説明</th><th>例</th></tr>
+    <tr><td><code>--year</code></td><td class="required">対象年（必須）</td><td><code>--year 2025</code></td></tr>
+    <tr><td><code>--month</code></td><td class="optional">対象月（省略時: 1-12月）</td><td><code>--month 1</code> / <code>--month 1-3</code></td></tr>
+    <tr><td><code>--store</code></td><td class="optional">店舗ID（省略時: 全店舗）</td><td><code>--store 6</code> / <code>--store 6,7,8</code></td></tr>
+    <tr><td><code>--staff</code></td><td class="optional">スタッフID</td><td><code>--staff 10,11,12</code></td></tr>
+    <tr><td><code>--clear</code></td><td class="optional">既存データを削除してから登録</td><td></td></tr>
+  </table>
+</div>
+
+<!-- ツール2: 第1案生成 -->
+<div class="tool-card">
+  <h3>② 第1案生成 (generate-first-plan.mjs)</h3>
+
+  <p>シフト第1案（FIRST Plan）を店舗ごとに生成します。</p>
+  <ul>
+    <li>希望シフトがあれば考慮（なくても動作します）</li>
+    <li>土日は多め、平日は少なめに人員配置</li>
+  </ul>
+
+  <h4>基本的な使い方</h4>
+  <pre><code># 確認のみ（2025年1月分）
+node scripts/tools/generate-first-plan.mjs --year 2025 --month 1
+
+# 実際に登録
+node scripts/tools/generate-first-plan.mjs --year 2025 --month 1 --execute
+
+# 削除
+node scripts/tools/generate-first-plan.mjs --year 2025 --month 1 --delete</code></pre>
+
+  <h4>オプション</h4>
+  <table>
+    <tr><th>オプション</th><th>説明</th><th>例</th></tr>
+    <tr><td><code>--year</code></td><td class="required">対象年（必須）</td><td><code>--year 2025</code></td></tr>
+    <tr><td><code>--month</code></td><td class="required">対象月（必須）</td><td><code>--month 1</code></td></tr>
+    <tr><td><code>--store</code></td><td class="optional">店舗ID（省略時: 全店舗）</td><td><code>--store 6,7</code></td></tr>
+    <tr><td><code>--clear</code></td><td class="optional">既存プランを削除してから登録</td><td></td></tr>
+  </table>
+</div>
+
+<!-- ツール3: 実績シフト生成 -->
+<div class="tool-card">
+  <h3>③ 実績シフト生成 (generate-actual-shifts.mjs)</h3>
+
+  <p>第1案をベースに、実績シフト（ACTUAL Plan）を生成します。</p>
+  <ul>
+    <li>一定確率で欠勤を発生</li>
+    <li>一定確率で時間変更（残業含む）を発生</li>
+  </ul>
+
+  <div class="warning">
+    <strong>前提条件:</strong> 第1案（FIRST Plan）が存在する必要があります。
+  </div>
+
+  <h4>基本的な使い方</h4>
+  <pre><code># 確認のみ
+node scripts/tools/generate-actual-shifts.mjs --year 2025 --month 1
+
+# 実際に登録（欠勤率10%、時間変更率15%）
+node scripts/tools/generate-actual-shifts.mjs --year 2025 --month 1 --absence 10 --time-change 15 --execute
+
+# 削除
+node scripts/tools/generate-actual-shifts.mjs --year 2025 --month 1 --delete</code></pre>
+
+  <h4>オプション</h4>
+  <table>
+    <tr><th>オプション</th><th>説明</th><th>デフォルト</th></tr>
+    <tr><td><code>--year</code></td><td class="required">対象年（必須）</td><td>-</td></tr>
+    <tr><td><code>--month</code></td><td class="required">対象月（必須）</td><td>-</td></tr>
+    <tr><td><code>--absence</code></td><td class="optional">欠勤率（%）</td><td>5</td></tr>
+    <tr><td><code>--time-change</code></td><td class="optional">時間変更率（%）</td><td>10</td></tr>
+    <tr><td><code>--store</code></td><td class="optional">店舗ID</td><td>全店舗</td></tr>
+  </table>
+</div>
+
+<!-- ツール4: スタッフ生成 -->
+<div class="tool-card">
+  <h3>④ スタッフ生成 (generate-staff.mjs)</h3>
+
+  <p>ダミーのスタッフデータを生成・管理します。</p>
+
+  <h4>基本的な使い方</h4>
+  <pre><code># スタッフ一覧を表示
+node scripts/tools/generate-staff.mjs --list
+
+# 10人のスタッフを生成（確認のみ）
+node scripts/tools/generate-staff.mjs --count 10
+
+# 店舗6に5人のアルバイトを登録
+node scripts/tools/generate-staff.mjs --count 5 --store 6 --type PART_TIME --execute
+
+# スタッフを削除（ID指定）
+node scripts/tools/generate-staff.mjs --delete --staff 100,101,102 --execute</code></pre>
+
+  <h4>オプション</h4>
+  <table>
+    <tr><th>オプション</th><th>説明</th><th>例</th></tr>
+    <tr><td><code>--list</code></td><td>現在のスタッフ一覧を表示</td><td></td></tr>
+    <tr><td><code>--count</code></td><td class="required">生成人数（生成時必須）</td><td><code>--count 10</code></td></tr>
+    <tr><td><code>--store</code></td><td class="optional">割当店舗ID</td><td><code>--store 6</code></td></tr>
+    <tr><td><code>--type</code></td><td class="optional">雇用形態</td><td><code>FULL_TIME</code> / <code>PART_TIME</code> / <code>CONTRACT</code></td></tr>
+    <tr><td><code>--delete</code></td><td>削除モード</td><td></td></tr>
+    <tr><td><code>--staff</code></td><td>削除対象のスタッフID</td><td><code>--staff 100,101</code></td></tr>
+  </table>
+</div>
+
+<!-- ツール5: データリセット -->
+<div class="tool-card">
+  <h3>⑤ データリセット (reset-data.mjs)</h3>
+
+  <p>テストデータを条件指定で削除します。</p>
+
+  <h4>削除対象テーブル</h4>
+  <table>
+    <tr><th>テーブル</th><th>内容</th><th>デフォルト</th></tr>
+    <tr><td><code>ops.shifts</code></td><td>シフトデータ</td><td>✅</td></tr>
+    <tr><td><code>ops.shift_preferences</code></td><td>希望シフト</td><td>✅</td></tr>
+    <tr><td><code>ops.shift_plans</code></td><td>シフトプラン</td><td>✅</td></tr>
+    <tr><td><code>ops.notifications</code></td><td>通知</td><td><code>--all</code>時のみ</td></tr>
+    <tr><td><code>hr.payroll</code></td><td>給与</td><td><code>--all</code>時のみ</td></tr>
+  </table>
+
+  <h4>基本的な使い方</h4>
+  <pre><code># 削除対象を確認（2025年1月分）
+node scripts/tools/reset-data.mjs --year 2025 --month 1
+
+# 実際に削除
+node scripts/tools/reset-data.mjs --year 2025 --month 1 --execute
+
+# 特定テーブルのみ削除
+node scripts/tools/reset-data.mjs --year 2025 --tables shifts,shift_preferences --execute
+
+# 全データ削除（マスタ以外）
+node scripts/tools/reset-data.mjs --all --execute</code></pre>
+
+  <h4>オプション</h4>
+  <table>
+    <tr><th>オプション</th><th>説明</th><th>例</th></tr>
+    <tr><td><code>--year</code></td><td class="optional">対象年</td><td><code>--year 2025</code></td></tr>
+    <tr><td><code>--month</code></td><td class="optional">対象月</td><td><code>--month 1</code></td></tr>
+    <tr><td><code>--store</code></td><td class="optional">店舗ID</td><td><code>--store 6</code></td></tr>
+    <tr><td><code>--tables</code></td><td class="optional">対象テーブル（カンマ区切り）</td><td><code>--tables shifts,shift_plans</code></td></tr>
+    <tr><td><code>--all</code></td><td class="optional">全データ削除（マスタ以外）</td><td></td></tr>
+  </table>
+</div>
+
+<h2>📝 よくある使い方の例</h2>
+
+<div class="success">
+  <h4>シナリオ1: 新しい月のテストデータを作成</h4>
+  <pre><code># 1. 希望シフトを生成
+node scripts/tools/generate-random-preferences.mjs --year 2025 --month 2 --execute
+
+# 2. 第1案を生成
+node scripts/tools/generate-first-plan.mjs --year 2025 --month 2 --execute
+
+# 3. 実績シフトを生成
+node scripts/tools/generate-actual-shifts.mjs --year 2025 --month 2 --execute</code></pre>
+</div>
+
+<div class="success">
+  <h4>シナリオ2: テストデータをクリーンアップ</h4>
+  <pre><code># 特定月のデータを削除
+node scripts/tools/reset-data.mjs --year 2025 --month 2 --execute</code></pre>
+</div>
+
+<div class="success">
+  <h4>シナリオ3: 大量のスタッフでテスト</h4>
+  <pre><code># 50人のアルバイトを追加
+node scripts/tools/generate-staff.mjs --count 50 --type PART_TIME --execute
+
+# テスト後に削除（IDを確認してから）
+node scripts/tools/generate-staff.mjs --list
+node scripts/tools/generate-staff.mjs --delete --staff 100,101,102,... --execute</code></pre>
+</div>
+
+<h2>🔧 トラブルシューティング</h2>
+
+<div class="tool-card">
+  <h4>Q: コマンドが動かない</h4>
+  <p>A: プロジェクトのルートディレクトリで実行しているか確認してください。</p>
+  <pre><code>cd /path/to/shift-scheduler-ai
+node scripts/tools/xxx.mjs --help</code></pre>
+
+  <h4>Q: DBに接続できない</h4>
+  <p>A: ネットワーク接続を確認してください。ツールはSTG環境（Railway）に直接接続します。</p>
+
+  <h4>Q: 間違ってデータを削除してしまった</h4>
+  <p>A: バックアップからリストアしてください。</p>
+  <pre><code># バックアップ取得
+pg_dump -h xxx -U postgres -d railway -F c -f backup.dump
+
+# リストア
+pg_restore -h xxx -U postgres -d railway --clean backup.dump</code></pre>
+</div>
+
+<hr>
+<p style="text-align: center; color: #7f8c8d;">
+  Last updated: 2024-11-27<br>
+  Issue: <a href="https://github.com/The-botch/shift-scheduler-ai/issues/86">#86</a>
+</p>
+
+</body>
+</html>

--- a/scripts/tools/generate-actual-shifts.mjs
+++ b/scripts/tools/generate-actual-shifts.mjs
@@ -1,0 +1,414 @@
+/**
+ * 実績シフトランダム生成ツール
+ *
+ * 使い方:
+ *   node scripts/tools/generate-actual-shifts.mjs --year 2025 --month 1 --dry-run
+ *   node scripts/tools/generate-actual-shifts.mjs --year 2025 --month 1 --execute
+ *   node scripts/tools/generate-actual-shifts.mjs --year 2025 --month 1 --store 6 --execute
+ *   node scripts/tools/generate-actual-shifts.mjs --year 2025 --month 1 --delete
+ *
+ * オプション:
+ *   --year        対象年（必須）
+ *   --month       対象月（必須）
+ *   --store       対象店舗ID（省略時: 全店舗、複数指定可: 6,7,8）
+ *   --absence     欠勤率（%、デフォルト: 5）
+ *   --time-change 時間変更率（%、デフォルト: 10）
+ *   --dry-run     生成データを表示するのみ（デフォルト）
+ *   --execute     実際にDBに登録する
+ *   --clear       既存データを削除してから登録
+ *   --delete      指定条件のデータを削除のみ（登録しない）
+ *
+ * 生成ロジック:
+ *   - 第1案（FIRST Plan）をベースに実績シフトを生成
+ *   - 一定確率で欠勤（シフトなし）を発生
+ *   - 一定確率で開始・終了時間を変更
+ *   - 残業（終了時間延長）も追加
+ */
+
+import pg from 'pg'
+const { Pool } = pg
+
+// 接続設定（STG環境）
+const pool = new Pool({
+  connectionString: 'postgresql://postgres:BWmHYBbEZqnptZRYmptockuomkHRWNPO@switchyard.proxy.rlwy.net:26491/railway',
+  ssl: { rejectUnauthorized: false }
+})
+
+// 引数パース
+const args = process.argv.slice(2)
+
+const getArg = (name) => {
+  const prefixed = args.find(a => a.startsWith(`--${name}=`))?.split('=')[1]
+  if (prefixed) return prefixed
+  const idx = args.indexOf(`--${name}`)
+  if (idx !== -1 && args[idx + 1] && !args[idx + 1].startsWith('--')) {
+    return args[idx + 1]
+  }
+  return null
+}
+
+const parseRange = (str) => {
+  if (!str) return null
+  if (str.includes(',')) {
+    return str.split(',').map(Number)
+  }
+  return [parseInt(str)]
+}
+
+const yearArg = getArg('year')
+const monthArg = getArg('month')
+const storeArg = getArg('store')
+const absenceRate = parseInt(getArg('absence') || '5') // 欠勤率（%）
+const timeChangeRate = parseInt(getArg('time-change') || '10') // 時間変更率（%）
+const isDryRun = !args.includes('--execute') && !args.includes('--delete')
+const shouldClear = args.includes('--clear')
+const deleteOnly = args.includes('--delete')
+
+// ヘルプ表示
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`
+使い方: node generate-actual-shifts.mjs --year <年> --month <月> [オプション]
+
+必須:
+  --year <年>          対象年（例: 2025）
+  --month <月>         対象月（例: 1）
+
+フィルタ:
+  --store <店舗ID>     対象店舗（例: 6, 6,7,8）省略時は全店舗
+
+変動パラメータ:
+  --absence <率>       欠勤率（%）デフォルト: 5
+  --time-change <率>   時間変更率（%）デフォルト: 10
+
+アクション:
+  --dry-run            確認のみ（デフォルト）
+  --execute            実際にDBに登録
+  --clear              既存データを削除してから登録
+  --delete             指定条件のデータを削除のみ
+
+例:
+  node generate-actual-shifts.mjs --year 2025 --month 1 --dry-run
+  node generate-actual-shifts.mjs --year 2025 --month 1 --execute
+  node generate-actual-shifts.mjs --year 2025 --month 1 --absence 10 --time-change 15 --execute
+  node generate-actual-shifts.mjs --year 2025 --month 1 --store 6 --execute
+  node generate-actual-shifts.mjs --year 2025 --month 1 --delete
+`)
+  process.exit(0)
+}
+
+if (!yearArg || !monthArg) {
+  console.error('エラー: --year と --month オプションを指定してください')
+  console.error('使い方を確認するには --help を実行してください')
+  process.exit(1)
+}
+
+const targetYear = parseInt(yearArg)
+const targetMonth = parseInt(monthArg)
+const targetStores = parseRange(storeArg)
+const TENANT_ID = 3 // テナントID
+
+// ランダムユーティリティ
+const randomInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min
+const randomFloat = (min, max) => Math.random() * (max - min) + min
+const shouldOccur = (percentChance) => Math.random() * 100 < percentChance
+
+// 時間を分に変換
+const timeToMinutes = (timeStr) => {
+  const [h, m] = timeStr.split(':').map(Number)
+  return h * 60 + m
+}
+
+// 分を時間文字列に変換
+const minutesToTime = (minutes) => {
+  const h = Math.floor(minutes / 60)
+  const m = minutes % 60
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+}
+
+// 月の日数を取得
+const getDaysInMonth = (year, month) => new Date(year, month, 0).getDate()
+
+// メイン処理
+async function main() {
+  console.log('='.repeat(60))
+  console.log(`実績シフトランダム生成ツール`)
+  console.log('='.repeat(60))
+  console.log(`対象年月: ${targetYear}年${targetMonth}月`)
+  console.log(`対象店舗: ${targetStores ? targetStores.join(', ') : '全店舗'}`)
+  console.log(`欠勤率: ${absenceRate}%`)
+  console.log(`時間変更率: ${timeChangeRate}%`)
+  console.log(`モード: ${deleteOnly ? '削除のみ' : (isDryRun ? 'ドライラン（表示のみ）' : '実行（DB登録）')}`)
+  console.log(`既存データ削除: ${shouldClear || deleteOnly ? 'あり' : 'なし'}`)
+  console.log('='.repeat(60))
+
+  try {
+    // 店舗一覧を取得
+    let storeQuery = `SELECT store_id, store_name FROM core.stores WHERE tenant_id = $1`
+    if (targetStores) {
+      storeQuery += ` AND store_id IN (${targetStores.join(',')})`
+    }
+    const storesResult = await pool.query(storeQuery, [TENANT_ID])
+    const stores = storesResult.rows
+
+    console.log(`\n対象店舗: ${stores.length}店舗`)
+    stores.forEach(s => console.log(`  - [${s.store_id}] ${s.store_name}`))
+
+    // 削除のみモード
+    if (deleteOnly) {
+      for (const store of stores) {
+        // ACTUALプランを検索
+        const planResult = await pool.query(`
+          SELECT plan_id FROM ops.shift_plans
+          WHERE tenant_id = $1 AND store_id = $2 AND plan_year = $3 AND plan_month = $4 AND plan_type = 'ACTUAL'
+        `, [TENANT_ID, store.store_id, targetYear, targetMonth])
+
+        if (planResult.rows.length > 0) {
+          const planId = planResult.rows[0].plan_id
+
+          // シフトを削除
+          const deleteShifts = await pool.query(`DELETE FROM ops.shifts WHERE plan_id = $1`, [planId])
+          console.log(`  [${store.store_name}] シフト削除: ${deleteShifts.rowCount}件`)
+
+          // プランを削除
+          await pool.query(`DELETE FROM ops.shift_plans WHERE plan_id = $1`, [planId])
+          console.log(`  [${store.store_name}] プラン削除: plan_id=${planId}`)
+        } else {
+          console.log(`  [${store.store_name}] 削除対象なし`)
+        }
+      }
+      return
+    }
+
+    // 第1案（FIRSTプラン）のシフトを取得
+    console.log('\n第1案のシフトを取得中...')
+
+    const allActualShifts = []
+    const allPlans = []
+    const lastDay = getDaysInMonth(targetYear, targetMonth)
+
+    let stats = {
+      totalFirstPlan: 0,
+      absences: 0,
+      timeChanges: 0,
+      overtimes: 0,
+      actualGenerated: 0,
+    }
+
+    for (const store of stores) {
+      console.log(`\n--- ${store.store_name} (ID: ${store.store_id}) ---`)
+
+      // 第1案のプランとシフトを取得
+      const firstPlanResult = await pool.query(`
+        SELECT sp.plan_id, s.shift_id, s.staff_id, s.shift_date, s.start_time, s.end_time,
+               s.break_minutes, s.total_hours, st.name as staff_name
+        FROM ops.shift_plans sp
+        JOIN ops.shifts s ON sp.plan_id = s.plan_id
+        JOIN hr.staff st ON s.staff_id = st.staff_id
+        WHERE sp.tenant_id = $1 AND sp.store_id = $2
+          AND sp.plan_year = $3 AND sp.plan_month = $4
+          AND sp.plan_type = 'FIRST'
+        ORDER BY s.shift_date, s.staff_id
+      `, [TENANT_ID, store.store_id, targetYear, targetMonth])
+
+      if (firstPlanResult.rows.length === 0) {
+        console.log(`  ⚠️ 第1案が存在しません。スキップします。`)
+        console.log(`  先に generate-first-plan.mjs で第1案を生成してください。`)
+        continue
+      }
+
+      console.log(`  第1案シフト数: ${firstPlanResult.rows.length}件`)
+      stats.totalFirstPlan += firstPlanResult.rows.length
+
+      // 第1案を元に実績シフトを生成
+      const actualShiftsForStore = []
+
+      for (const shift of firstPlanResult.rows) {
+        // 欠勤判定
+        if (shouldOccur(absenceRate)) {
+          stats.absences++
+          continue // このシフトは欠勤として実績に含めない
+        }
+
+        // シフトデータのコピー
+        let startTime = shift.start_time
+        let endTime = shift.end_time
+        let isModified = false
+
+        // 時間変更判定
+        if (shouldOccur(timeChangeRate)) {
+          stats.timeChanges++
+          isModified = true
+
+          // 開始時間を前後30分程度変更
+          const startMinutes = timeToMinutes(startTime)
+          const startVariation = randomInt(-30, 30)
+          const newStartMinutes = Math.max(360, Math.min(1200, startMinutes + startVariation)) // 6:00〜20:00
+          startTime = minutesToTime(newStartMinutes)
+
+          // 終了時間を前後30分程度変更（残業含む）
+          const endMinutes = timeToMinutes(endTime)
+          const endVariation = randomInt(-15, 60) // 早退は15分まで、残業は60分まで
+          const newEndMinutes = Math.max(newStartMinutes + 180, Math.min(1380, endMinutes + endVariation)) // 最低3時間、最大23:00
+          endTime = minutesToTime(newEndMinutes)
+
+          if (endVariation > 0) {
+            stats.overtimes++
+          }
+        }
+
+        // 勤務時間を再計算
+        const startMinutes = timeToMinutes(startTime)
+        const endMinutes = timeToMinutes(endTime)
+        const breakMinutes = shift.break_minutes || 60
+        const totalMinutes = endMinutes - startMinutes - breakMinutes
+        const totalHours = Math.round(totalMinutes / 60 * 100) / 100
+
+        actualShiftsForStore.push({
+          tenant_id: TENANT_ID,
+          store_id: store.store_id,
+          staff_id: shift.staff_id,
+          shift_date: shift.shift_date instanceof Date
+            ? shift.shift_date.toISOString().split('T')[0]
+            : shift.shift_date,
+          start_time: startTime,
+          end_time: endTime,
+          break_minutes: breakMinutes,
+          total_hours: totalHours,
+          is_preferred: false,
+          is_modified: isModified,
+          staff_name: shift.staff_name,
+        })
+      }
+
+      console.log(`  実績シフト生成: ${actualShiftsForStore.length}件`)
+      console.log(`    - 欠勤: ${stats.absences}件（この店舗まで累計）`)
+      console.log(`    - 時間変更: ${stats.timeChanges}件（この店舗まで累計）`)
+
+      stats.actualGenerated += actualShiftsForStore.length
+
+      allPlans.push({
+        tenant_id: TENANT_ID,
+        store_id: store.store_id,
+        store_name: store.store_name,
+        plan_year: targetYear,
+        plan_month: targetMonth,
+        plan_type: 'ACTUAL',
+        status: 'APPROVED',
+        shifts: actualShiftsForStore,
+      })
+
+      allActualShifts.push(...actualShiftsForStore)
+    }
+
+    // サマリ表示
+    console.log('\n=== 生成サマリ ===')
+    console.log(`第1案シフト総数: ${stats.totalFirstPlan}件`)
+    console.log(`実績シフト総数: ${stats.actualGenerated}件`)
+    console.log(`欠勤数: ${stats.absences}件 (${(stats.absences / stats.totalFirstPlan * 100).toFixed(1)}%)`)
+    console.log(`時間変更数: ${stats.timeChanges}件 (${(stats.timeChanges / stats.totalFirstPlan * 100).toFixed(1)}%)`)
+    console.log(`残業含む: ${stats.overtimes}件`)
+
+    allPlans.forEach(plan => {
+      console.log(`  [${plan.store_name}] ${plan.shifts.length}件`)
+    })
+
+    // サンプルデータ表示
+    console.log('\n=== サンプルデータ（最初の10件） ===')
+    allActualShifts.slice(0, 10).forEach(s => {
+      const modified = s.is_modified ? ' [変更]' : ''
+      console.log(`  ${s.shift_date} | store:${s.store_id} | ${s.staff_name} | ${s.start_time}-${s.end_time}${modified}`)
+    })
+
+    if (isDryRun) {
+      console.log('\n[ドライラン] 実際の登録は行いません。')
+      console.log('登録するには --execute オプションを付けて実行してください。')
+    } else {
+      console.log('\n登録を開始します...')
+
+      for (const plan of allPlans) {
+        if (plan.shifts.length === 0) continue
+
+        // 既存プランをチェック＆削除（--clearの場合）
+        if (shouldClear) {
+          const existingPlan = await pool.query(`
+            SELECT plan_id FROM ops.shift_plans
+            WHERE tenant_id = $1 AND store_id = $2 AND plan_year = $3 AND plan_month = $4 AND plan_type = 'ACTUAL'
+          `, [TENANT_ID, plan.store_id, targetYear, targetMonth])
+
+          if (existingPlan.rows.length > 0) {
+            const oldPlanId = existingPlan.rows[0].plan_id
+            await pool.query(`DELETE FROM ops.shifts WHERE plan_id = $1`, [oldPlanId])
+            await pool.query(`DELETE FROM ops.shift_plans WHERE plan_id = $1`, [oldPlanId])
+            console.log(`  [${plan.store_name}] 既存プラン削除: plan_id=${oldPlanId}`)
+          }
+        }
+
+        // プランを作成
+        const periodStart = `${targetYear}-${String(targetMonth).padStart(2, '0')}-01`
+        const periodEnd = `${targetYear}-${String(targetMonth).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
+
+        const planResult = await pool.query(`
+          INSERT INTO ops.shift_plans (
+            tenant_id, store_id, plan_year, plan_month, plan_code, plan_name,
+            period_start, period_end, status, plan_type, generation_type
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+          RETURNING plan_id
+        `, [
+          TENANT_ID,
+          plan.store_id,
+          targetYear,
+          targetMonth,
+          `ACTUAL-${targetYear}${String(targetMonth).padStart(2, '0')}-${plan.store_id}`,
+          `${targetYear}年${targetMonth}月 実績 (${plan.store_name})`,
+          periodStart,
+          periodEnd,
+          'APPROVED',
+          'ACTUAL',
+          'MANUAL'
+        ])
+
+        const planId = planResult.rows[0].plan_id
+        console.log(`  [${plan.store_name}] プラン作成: plan_id=${planId}`)
+
+        // シフトをバッチ挿入
+        const batchSize = 500
+        let inserted = 0
+
+        for (let i = 0; i < plan.shifts.length; i += batchSize) {
+          const batch = plan.shifts.slice(i, i + batchSize)
+
+          const values = batch.map((_, idx) => {
+            const base = idx * 10
+            return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7}, $${base + 8}, $${base + 9}, $${base + 10})`
+          }).join(', ')
+
+          const params = batch.flatMap(s => [
+            TENANT_ID, plan.store_id, planId, s.staff_id, s.shift_date,
+            s.start_time, s.end_time, s.break_minutes, s.total_hours, s.is_modified
+          ])
+
+          await pool.query(`
+            INSERT INTO ops.shifts (
+              tenant_id, store_id, plan_id, staff_id, shift_date,
+              start_time, end_time, break_minutes, total_hours, is_modified
+            ) VALUES ${values}
+          `, params)
+
+          inserted += batch.length
+        }
+
+        console.log(`  [${plan.store_name}] シフト登録: ${inserted}件`)
+      }
+
+      console.log(`\n登録完了`)
+    }
+
+  } catch (error) {
+    console.error('エラー:', error)
+    process.exit(1)
+  } finally {
+    await pool.end()
+  }
+}
+
+main()

--- a/scripts/tools/generate-first-plan.mjs
+++ b/scripts/tools/generate-first-plan.mjs
@@ -1,0 +1,408 @@
+/**
+ * 第1案（First Plan）ランダム生成ツール
+ *
+ * 使い方:
+ *   node scripts/tools/generate-first-plan.mjs --year 2025 --month 1 --dry-run
+ *   node scripts/tools/generate-first-plan.mjs --year 2025 --month 1 --execute
+ *   node scripts/tools/generate-first-plan.mjs --year 2025 --month 1 --store 6 --execute
+ *   node scripts/tools/generate-first-plan.mjs --year 2025 --month 1 --delete
+ *
+ * オプション:
+ *   --year      対象年（必須）
+ *   --month     対象月（必須）
+ *   --store     対象店舗ID（省略時: 全店舗、複数指定可: 6,7,8）
+ *   --dry-run   生成データを表示するのみ（デフォルト）
+ *   --execute   実際にDBに登録する
+ *   --clear     既存データを削除してから登録
+ *   --delete    指定条件のデータを削除のみ（登録しない）
+ */
+
+import pg from 'pg'
+const { Pool } = pg
+
+// 接続設定（STG環境）
+const pool = new Pool({
+  connectionString: 'postgresql://postgres:BWmHYBbEZqnptZRYmptockuomkHRWNPO@switchyard.proxy.rlwy.net:26491/railway',
+  ssl: { rejectUnauthorized: false }
+})
+
+// 引数パース
+const args = process.argv.slice(2)
+
+const getArg = (name) => {
+  const prefixed = args.find(a => a.startsWith(`--${name}=`))?.split('=')[1]
+  if (prefixed) return prefixed
+  const idx = args.indexOf(`--${name}`)
+  if (idx !== -1 && args[idx + 1] && !args[idx + 1].startsWith('--')) {
+    return args[idx + 1]
+  }
+  return null
+}
+
+const parseRange = (str) => {
+  if (!str) return null
+  if (str.includes(',')) {
+    return str.split(',').map(Number)
+  }
+  return [parseInt(str)]
+}
+
+const yearArg = getArg('year')
+const monthArg = getArg('month')
+const storeArg = getArg('store')
+const isDryRun = !args.includes('--execute') && !args.includes('--delete')
+const shouldClear = args.includes('--clear')
+const deleteOnly = args.includes('--delete')
+
+if (!yearArg || !monthArg) {
+  console.error(`
+使い方: node generate-first-plan.mjs --year <年> --month <月> [オプション]
+
+必須:
+  --year <年>        対象年（例: 2025）
+  --month <月>       対象月（例: 1）
+
+フィルタ:
+  --store <店舗ID>   対象店舗（例: 6, 6,7,8）省略時は全店舗
+
+アクション:
+  --dry-run          確認のみ（デフォルト）
+  --execute          実際にDBに登録
+  --clear            既存データを削除してから登録
+  --delete           指定条件のデータを削除のみ
+
+例:
+  node generate-first-plan.mjs --year 2025 --month 1 --dry-run
+  node generate-first-plan.mjs --year 2025 --month 1 --execute
+  node generate-first-plan.mjs --year 2025 --month 1 --store 6 --execute
+  node generate-first-plan.mjs --year 2025 --month 1 --delete
+`)
+  process.exit(1)
+}
+
+const targetYear = parseInt(yearArg)
+const targetMonth = parseInt(monthArg)
+const targetStores = parseRange(storeArg)
+const TENANT_ID = 3 // テナントID
+
+// ランダムユーティリティ
+const randomInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min
+const randomChoice = (arr) => arr[Math.floor(Math.random() * arr.length)]
+const shuffleArray = (arr) => [...arr].sort(() => Math.random() - 0.5)
+
+// 月の日数を取得
+const getDaysInMonth = (year, month) => new Date(year, month, 0).getDate()
+
+// 曜日を取得（0=日, 1=月, ...）
+const getDayOfWeek = (year, month, day) => new Date(year, month - 1, day).getDay()
+
+// シフトパターン（デフォルト）
+const SHIFT_PATTERNS = [
+  { start: '09:00', end: '18:00', break: 60 },  // 日勤
+  { start: '10:00', end: '19:00', break: 60 },  // 中番
+  { start: '11:00', end: '20:00', break: 60 },  // 遅番1
+  { start: '14:00', end: '22:00', break: 60 },  // 遅番2
+]
+
+// メイン処理
+async function main() {
+  console.log('='.repeat(60))
+  console.log(`第1案（First Plan）ランダム生成ツール`)
+  console.log('='.repeat(60))
+  console.log(`対象年月: ${targetYear}年${targetMonth}月`)
+  console.log(`対象店舗: ${targetStores ? targetStores.join(', ') : '全店舗'}`)
+  console.log(`モード: ${deleteOnly ? '削除のみ' : (isDryRun ? 'ドライラン（表示のみ）' : '実行（DB登録）')}`)
+  console.log(`既存データ削除: ${shouldClear || deleteOnly ? 'あり' : 'なし'}`)
+  console.log('='.repeat(60))
+
+  try {
+    // 店舗一覧を取得
+    let storeQuery = `SELECT store_id, store_name FROM core.stores WHERE tenant_id = $1`
+    if (targetStores) {
+      storeQuery += ` AND store_id IN (${targetStores.join(',')})`
+    }
+    const storesResult = await pool.query(storeQuery, [TENANT_ID])
+    const stores = storesResult.rows
+
+    console.log(`\n対象店舗: ${stores.length}店舗`)
+    stores.forEach(s => console.log(`  - [${s.store_id}] ${s.store_name}`))
+
+    // 削除のみモード
+    if (deleteOnly) {
+      for (const store of stores) {
+        // プランを検索
+        const planResult = await pool.query(`
+          SELECT plan_id FROM ops.shift_plans
+          WHERE tenant_id = $1 AND store_id = $2 AND plan_year = $3 AND plan_month = $4 AND plan_type = 'FIRST'
+        `, [TENANT_ID, store.store_id, targetYear, targetMonth])
+
+        if (planResult.rows.length > 0) {
+          const planId = planResult.rows[0].plan_id
+
+          // シフトを削除
+          const deleteShifts = await pool.query(`DELETE FROM ops.shifts WHERE plan_id = $1`, [planId])
+          console.log(`  [${store.store_name}] シフト削除: ${deleteShifts.rowCount}件`)
+
+          // プランを削除
+          await pool.query(`DELETE FROM ops.shift_plans WHERE plan_id = $1`, [planId])
+          console.log(`  [${store.store_name}] プラン削除: plan_id=${planId}`)
+        } else {
+          console.log(`  [${store.store_name}] 削除対象なし`)
+        }
+      }
+      return
+    }
+
+    // 希望シフトを取得（該当月）
+    const dateFrom = `${targetYear}-${String(targetMonth).padStart(2, '0')}-01`
+    const lastDay = getDaysInMonth(targetYear, targetMonth)
+    const dateTo = `${targetYear}-${String(targetMonth).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
+
+    const prefsResult = await pool.query(`
+      SELECT staff_id, store_id, preference_date, is_ng, start_time, end_time
+      FROM ops.shift_preferences
+      WHERE tenant_id = $1 AND preference_date >= $2 AND preference_date <= $3
+    `, [TENANT_ID, dateFrom, dateTo])
+
+    console.log(`\n希望シフト取得: ${prefsResult.rows.length}件`)
+
+    // スタッフごとの希望日マップを作成
+    const staffPreferences = {}
+    prefsResult.rows.forEach(pref => {
+      const staffId = pref.staff_id
+      if (!staffPreferences[staffId]) {
+        staffPreferences[staffId] = {
+          storeId: pref.store_id,
+          availableDays: [],
+          ngDays: [],
+        }
+      }
+      const day = new Date(pref.preference_date).getDate()
+      if (pref.is_ng) {
+        staffPreferences[staffId].ngDays.push(day)
+      } else {
+        staffPreferences[staffId].availableDays.push({
+          day,
+          start_time: pref.start_time,
+          end_time: pref.end_time,
+        })
+      }
+    })
+
+    // スタッフ一覧を取得
+    const staffResult = await pool.query(`
+      SELECT staff_id, name, store_id, employment_type
+      FROM hr.staff
+      WHERE is_active = true AND tenant_id = $1
+    `, [TENANT_ID])
+
+    const allStaff = staffResult.rows
+    console.log(`アクティブスタッフ: ${allStaff.length}名`)
+
+    // 店舗ごとにプランとシフトを生成
+    const allPlans = []
+    const allShifts = []
+
+    for (const store of stores) {
+      console.log(`\n--- ${store.store_name} (ID: ${store.store_id}) ---`)
+
+      // この店舗のスタッフを取得
+      const storeStaff = allStaff.filter(s => parseInt(s.store_id) === parseInt(store.store_id))
+      console.log(`  スタッフ数: ${storeStaff.length}名`)
+
+      if (storeStaff.length === 0) {
+        console.log(`  スキップ（スタッフなし）`)
+        continue
+      }
+
+      // 月の各日にシフトを生成
+      const daysInMonth = getDaysInMonth(targetYear, targetMonth)
+      const shiftsForStore = []
+
+      for (let day = 1; day <= daysInMonth; day++) {
+        const dateStr = `${targetYear}-${String(targetMonth).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+        const dayOfWeek = getDayOfWeek(targetYear, targetMonth, day)
+
+        // 曜日によって必要人数を変える（土日は多め）
+        const isWeekend = dayOfWeek === 0 || dayOfWeek === 6
+        const requiredStaff = isWeekend ? randomInt(4, 6) : randomInt(2, 4)
+
+        // この日に勤務可能なスタッフをシャッフル
+        const availableStaff = storeStaff.filter(staff => {
+          const pref = staffPreferences[staff.staff_id]
+          // NG日でないスタッフ
+          if (pref && pref.ngDays.includes(day)) return false
+          return true
+        })
+
+        const shuffledStaff = shuffleArray(availableStaff)
+        const assignedStaff = shuffledStaff.slice(0, Math.min(requiredStaff, shuffledStaff.length))
+
+        // 各スタッフにシフトを割り当て
+        assignedStaff.forEach(staff => {
+          const pref = staffPreferences[staff.staff_id]
+          let pattern
+
+          // 希望時間がある場合はそれを使用
+          if (pref) {
+            const dayPref = pref.availableDays.find(d => d.day === day)
+            if (dayPref && dayPref.start_time && dayPref.end_time) {
+              pattern = {
+                start: dayPref.start_time,
+                end: dayPref.end_time,
+                break: 60,
+              }
+            }
+          }
+
+          // 希望がない場合はランダムなパターンを使用
+          if (!pattern) {
+            pattern = randomChoice(SHIFT_PATTERNS)
+          }
+
+          // 勤務時間を計算
+          const [startH, startM] = pattern.start.split(':').map(Number)
+          const [endH, endM] = pattern.end.split(':').map(Number)
+          const totalMinutes = (endH * 60 + endM) - (startH * 60 + startM) - pattern.break
+          const totalHours = totalMinutes / 60
+
+          shiftsForStore.push({
+            tenant_id: TENANT_ID,
+            store_id: store.store_id,
+            staff_id: staff.staff_id,
+            shift_date: dateStr,
+            start_time: pattern.start,
+            end_time: pattern.end,
+            break_minutes: pattern.break,
+            total_hours: totalHours,
+            is_preferred: pref?.availableDays.some(d => d.day === day) || false,
+            is_modified: false,
+            staff_name: staff.name,
+          })
+        })
+      }
+
+      console.log(`  生成シフト数: ${shiftsForStore.length}件`)
+
+      allPlans.push({
+        tenant_id: TENANT_ID,
+        store_id: store.store_id,
+        store_name: store.store_name,
+        plan_year: targetYear,
+        plan_month: targetMonth,
+        plan_type: 'FIRST',
+        status: 'DRAFT',
+        shifts: shiftsForStore,
+      })
+
+      allShifts.push(...shiftsForStore)
+    }
+
+    // サマリ表示
+    console.log('\n=== 生成サマリ ===')
+    console.log(`プラン数: ${allPlans.length}`)
+    console.log(`シフト総数: ${allShifts.length}`)
+
+    allPlans.forEach(plan => {
+      console.log(`  [${plan.store_name}] ${plan.shifts.length}件`)
+    })
+
+    // サンプルデータ表示
+    console.log('\n=== サンプルデータ（最初の10件） ===')
+    allShifts.slice(0, 10).forEach(s => {
+      console.log(`  ${s.shift_date} | store:${s.store_id} | ${s.staff_name} | ${s.start_time}-${s.end_time}`)
+    })
+
+    if (isDryRun) {
+      console.log('\n[ドライラン] 実際の登録は行いません。')
+      console.log('登録するには --execute オプションを付けて実行してください。')
+    } else {
+      console.log('\n登録を開始します...')
+
+      for (const plan of allPlans) {
+        // 既存プランをチェック＆削除（--clearの場合）
+        if (shouldClear) {
+          const existingPlan = await pool.query(`
+            SELECT plan_id FROM ops.shift_plans
+            WHERE tenant_id = $1 AND store_id = $2 AND plan_year = $3 AND plan_month = $4 AND plan_type = 'FIRST'
+          `, [TENANT_ID, plan.store_id, targetYear, targetMonth])
+
+          if (existingPlan.rows.length > 0) {
+            const oldPlanId = existingPlan.rows[0].plan_id
+            await pool.query(`DELETE FROM ops.shifts WHERE plan_id = $1`, [oldPlanId])
+            await pool.query(`DELETE FROM ops.shift_plans WHERE plan_id = $1`, [oldPlanId])
+            console.log(`  [${plan.store_name}] 既存プラン削除: plan_id=${oldPlanId}`)
+          }
+        }
+
+        // プランを作成
+        const periodStart = `${targetYear}-${String(targetMonth).padStart(2, '0')}-01`
+        const periodEnd = `${targetYear}-${String(targetMonth).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
+
+        const planResult = await pool.query(`
+          INSERT INTO ops.shift_plans (
+            tenant_id, store_id, plan_year, plan_month, plan_code, plan_name,
+            period_start, period_end, status, plan_type, generation_type
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+          RETURNING plan_id
+        `, [
+          TENANT_ID,
+          plan.store_id,
+          targetYear,
+          targetMonth,
+          `FIRST-${targetYear}${String(targetMonth).padStart(2, '0')}-${plan.store_id}`,
+          `${targetYear}年${targetMonth}月 第1案 (${plan.store_name})`,
+          periodStart,
+          periodEnd,
+          'DRAFT',
+          'FIRST',
+          'MANUAL'
+        ])
+
+        const planId = planResult.rows[0].plan_id
+        console.log(`  [${plan.store_name}] プラン作成: plan_id=${planId}`)
+
+        // シフトをバッチ挿入
+        if (plan.shifts.length > 0) {
+          const batchSize = 500
+          let inserted = 0
+
+          for (let i = 0; i < plan.shifts.length; i += batchSize) {
+            const batch = plan.shifts.slice(i, i + batchSize)
+
+            const values = batch.map((_, idx) => {
+              const base = idx * 10
+              return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7}, $${base + 8}, $${base + 9}, $${base + 10})`
+            }).join(', ')
+
+            const params = batch.flatMap(s => [
+              TENANT_ID, plan.store_id, planId, s.staff_id, s.shift_date,
+              s.start_time, s.end_time, s.break_minutes, s.total_hours, s.is_preferred
+            ])
+
+            await pool.query(`
+              INSERT INTO ops.shifts (
+                tenant_id, store_id, plan_id, staff_id, shift_date,
+                start_time, end_time, break_minutes, total_hours, is_preferred
+              ) VALUES ${values}
+            `, params)
+
+            inserted += batch.length
+          }
+
+          console.log(`  [${plan.store_name}] シフト登録: ${inserted}件`)
+        }
+      }
+
+      console.log(`\n登録完了`)
+    }
+
+  } catch (error) {
+    console.error('エラー:', error)
+    process.exit(1)
+  } finally {
+    await pool.end()
+  }
+}
+
+main()

--- a/scripts/tools/generate-random-preferences.mjs
+++ b/scripts/tools/generate-random-preferences.mjs
@@ -1,0 +1,378 @@
+/**
+ * 希望シフトランダム生成ツール
+ *
+ * 使い方:
+ *   node scripts/tools/generate-random-preferences.mjs --year 2025 --dry-run
+ *   node scripts/tools/generate-random-preferences.mjs --year 2025 --month 1 --execute
+ *   node scripts/tools/generate-random-preferences.mjs --year 2025 --store 6 --execute
+ *   node scripts/tools/generate-random-preferences.mjs --year 2025 --month 1-3 --execute
+ *   node scripts/tools/generate-random-preferences.mjs --year 2025 --delete
+ *
+ * オプション:
+ *   --year      対象年（必須）
+ *   --month     対象月（省略時: 1-12全月、範囲指定可: 1-3, 単月: 6）
+ *   --store     対象店舗ID（省略時: 全店舗、複数指定可: 6,7,8）
+ *   --staff     対象スタッフID（省略時: 全スタッフ、複数指定可: 1,2,3）
+ *   --dry-run   生成データを表示するのみ（デフォルト）
+ *   --execute   実際にDBに登録する
+ *   --clear     既存データを削除してから登録
+ *   --delete    指定条件のデータを削除のみ（登録しない）
+ */
+
+import pg from 'pg'
+const { Pool } = pg
+
+// 接続設定（STG環境）
+const pool = new Pool({
+  connectionString: 'postgresql://postgres:BWmHYBbEZqnptZRYmptockuomkHRWNPO@switchyard.proxy.rlwy.net:26491/railway',
+  ssl: { rejectUnauthorized: false }
+})
+
+// 引数パース
+const args = process.argv.slice(2)
+
+const getArg = (name) => {
+  const prefixed = args.find(a => a.startsWith(`--${name}=`))?.split('=')[1]
+  if (prefixed) return prefixed
+  const idx = args.indexOf(`--${name}`)
+  if (idx !== -1 && args[idx + 1] && !args[idx + 1].startsWith('--')) {
+    return args[idx + 1]
+  }
+  return null
+}
+
+const parseRange = (str) => {
+  if (!str) return null
+  if (str.includes('-')) {
+    const [start, end] = str.split('-').map(Number)
+    return Array.from({ length: end - start + 1 }, (_, i) => start + i)
+  }
+  if (str.includes(',')) {
+    return str.split(',').map(Number)
+  }
+  return [parseInt(str)]
+}
+
+const yearArg = getArg('year')
+const monthArg = getArg('month')
+const storeArg = getArg('store')
+const staffArg = getArg('staff')
+const isDryRun = !args.includes('--execute') && !args.includes('--delete')
+const shouldClear = args.includes('--clear')
+const deleteOnly = args.includes('--delete')
+
+if (!yearArg) {
+  console.error(`
+使い方: node generate-random-preferences.mjs --year <年> [オプション]
+
+必須:
+  --year <年>        対象年（例: 2025）
+
+フィルタ:
+  --month <月>       対象月（例: 1, 1-3, 1,2,3）省略時は1-12月
+  --store <店舗ID>   対象店舗（例: 6, 6,7,8）省略時は全店舗
+  --staff <スタッフID> 対象スタッフ（例: 56, 1,2,3）省略時は全スタッフ
+
+アクション:
+  --dry-run          確認のみ（デフォルト）
+  --execute          実際にDBに登録
+  --clear            既存データを削除してから登録
+  --delete           指定条件のデータを削除のみ
+
+例:
+  node generate-random-preferences.mjs --year 2025 --dry-run
+  node generate-random-preferences.mjs --year 2025 --month 1 --execute
+  node generate-random-preferences.mjs --year 2025 --store 6,7 --execute
+  node generate-random-preferences.mjs --year 2025 --month 1-6 --delete
+`)
+  process.exit(1)
+}
+
+const targetYear = parseInt(yearArg)
+const targetMonths = parseRange(monthArg) || Array.from({ length: 12 }, (_, i) => i + 1)
+const targetStores = parseRange(storeArg)
+const targetStaffIds = parseRange(staffArg)
+const TENANT_ID = 3 // テナントID
+
+// ランダムユーティリティ
+const randomInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min
+const randomChoice = (arr) => arr[Math.floor(Math.random() * arr.length)]
+const shuffleArray = (arr) => arr.sort(() => Math.random() - 0.5)
+
+// 時間パターン（アルバイト用）
+const TIME_PATTERNS = [
+  { start: '09:00', end: '14:00' },  // 早番
+  { start: '14:00', end: '22:00' },  // 遅番
+  { start: '09:00', end: '18:00' },  // 日勤
+  { start: '10:00', end: '19:00' },  // 中番
+  { start: '17:00', end: '22:00' },  // 夕方のみ
+  { start: '09:00', end: '22:00' },  // 通し
+]
+
+// 月の日数を取得
+const getDaysInMonth = (year, month) => new Date(year, month, 0).getDate()
+
+// スタッフの希望パターンを決定
+const getStaffPreferencePattern = (staff, staffIndex) => {
+  const isFullTime = staff.employment_type === 'FULL_TIME'
+
+  if (isFullTime) {
+    const pattern = staffIndex % 10
+    if (pattern < 3) return { type: 'NO_NG', ngDaysPerMonth: 0 }
+    if (pattern < 7) return { type: 'FEW_NG', ngDaysPerMonth: randomInt(1, 2) }
+    return { type: 'SOME_NG', ngDaysPerMonth: randomInt(3, 5) }
+  } else {
+    const pattern = staffIndex % 10
+    if (pattern < 3) return { type: 'FEW_SHIFTS', shiftDaysPerMonth: randomInt(5, 8) }
+    if (pattern < 8) return { type: 'NORMAL_SHIFTS', shiftDaysPerMonth: randomInt(8, 12) }
+    return { type: 'MANY_SHIFTS', shiftDaysPerMonth: randomInt(12, 18) }
+  }
+}
+
+// 1ヶ月分の希望を生成
+const generateMonthPreferences = (staff, year, month, pattern) => {
+  const preferences = []
+  const daysInMonth = getDaysInMonth(year, month)
+  const isFullTime = staff.employment_type === 'FULL_TIME'
+
+  const allDays = Array.from({ length: daysInMonth }, (_, i) => i + 1)
+  const shuffledDays = shuffleArray([...allDays])
+
+  if (isFullTime) {
+    if (pattern.ngDaysPerMonth === 0) return []
+
+    const ngDays = shuffledDays.slice(0, pattern.ngDaysPerMonth)
+    ngDays.forEach(day => {
+      const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+      preferences.push({
+        tenant_id: TENANT_ID,
+        store_id: staff.store_id,
+        staff_id: staff.staff_id,
+        preference_date: dateStr,
+        is_ng: true,
+        start_time: null,
+        end_time: null,
+        notes: null
+      })
+    })
+  } else {
+    const shiftDays = shuffledDays.slice(0, pattern.shiftDaysPerMonth)
+    shiftDays.forEach(day => {
+      const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+      const timePattern = randomChoice(TIME_PATTERNS)
+
+      const notes = Math.random() < 0.1
+        ? randomChoice(['この日は早めに上がりたいです', '遅刻する可能性あり', '研修参加のため', null])
+        : null
+
+      preferences.push({
+        tenant_id: TENANT_ID,
+        store_id: staff.store_id,
+        staff_id: staff.staff_id,
+        preference_date: dateStr,
+        is_ng: false,
+        start_time: timePattern.start,
+        end_time: timePattern.end,
+        notes
+      })
+    })
+  }
+
+  return preferences
+}
+
+// 削除用のWHERE句を構築
+const buildWhereClause = () => {
+  const conditions = [`tenant_id = ${TENANT_ID}`, `EXTRACT(YEAR FROM preference_date) = ${targetYear}`]
+
+  if (targetMonths.length < 12) {
+    conditions.push(`EXTRACT(MONTH FROM preference_date) IN (${targetMonths.join(',')})`)
+  }
+  if (targetStores) {
+    conditions.push(`store_id IN (${targetStores.join(',')})`)
+  }
+  if (targetStaffIds) {
+    conditions.push(`staff_id IN (${targetStaffIds.join(',')})`)
+  }
+
+  return conditions.join(' AND ')
+}
+
+// メイン処理
+async function main() {
+  console.log('='.repeat(60))
+  console.log(`希望シフトランダム生成ツール`)
+  console.log('='.repeat(60))
+  console.log(`対象年: ${targetYear}`)
+  console.log(`対象月: ${targetMonths.join(', ')}月`)
+  console.log(`対象店舗: ${targetStores ? targetStores.join(', ') : '全店舗'}`)
+  console.log(`対象スタッフ: ${targetStaffIds ? targetStaffIds.join(', ') : '全スタッフ'}`)
+  console.log(`モード: ${deleteOnly ? '削除のみ' : (isDryRun ? 'ドライラン（表示のみ）' : '実行（DB登録）')}`)
+  console.log(`既存データ削除: ${shouldClear || deleteOnly ? 'あり' : 'なし'}`)
+  console.log('='.repeat(60))
+
+  // 削除のみモード
+  if (deleteOnly) {
+    try {
+      const whereClause = buildWhereClause()
+
+      const countResult = await pool.query(`
+        SELECT COUNT(*) as count FROM ops.shift_preferences WHERE ${whereClause}
+      `)
+
+      const count = parseInt(countResult.rows[0].count)
+      console.log(`\n対象データ: ${count}件`)
+
+      if (count === 0) {
+        console.log('削除するデータがありません。')
+      } else {
+        console.log('削除を実行します...')
+        const deleteResult = await pool.query(`
+          DELETE FROM ops.shift_preferences WHERE ${whereClause}
+        `)
+        console.log(`削除完了: ${deleteResult.rowCount}件`)
+      }
+    } catch (error) {
+      console.error('エラー:', error)
+      process.exit(1)
+    } finally {
+      await pool.end()
+    }
+    return
+  }
+
+  try {
+    // アクティブスタッフを取得
+    let staffQuery = `
+      SELECT staff_id, name, store_id, employment_type
+      FROM hr.staff
+      WHERE is_active = true AND tenant_id = $1
+    `
+    const queryParams = [TENANT_ID]
+
+    if (targetStores) {
+      staffQuery += ` AND store_id IN (${targetStores.join(',')})`
+    }
+    if (targetStaffIds) {
+      staffQuery += ` AND staff_id IN (${targetStaffIds.join(',')})`
+    }
+    staffQuery += ` ORDER BY employment_type, staff_id`
+
+    const staffResult = await pool.query(staffQuery, queryParams)
+
+    const staffList = staffResult.rows
+    console.log(`\n対象スタッフ: ${staffList.length}名`)
+    console.log(`  - 社員(FULL_TIME): ${staffList.filter(s => s.employment_type === 'FULL_TIME').length}名`)
+    console.log(`  - アルバイト(PART_TIME): ${staffList.filter(s => s.employment_type === 'PART_TIME').length}名`)
+
+    // 全希望データを生成
+    const allPreferences = []
+    const summaryByStaff = []
+
+    staffList.forEach((staff, index) => {
+      const pattern = getStaffPreferencePattern(staff, index)
+      let totalPrefs = 0
+
+      targetMonths.forEach(month => {
+        const monthPrefs = generateMonthPreferences(staff, targetYear, month, pattern)
+        allPreferences.push(...monthPrefs)
+        totalPrefs += monthPrefs.length
+      })
+
+      summaryByStaff.push({
+        staff_id: staff.staff_id,
+        name: staff.name,
+        store_id: staff.store_id,
+        type: staff.employment_type,
+        pattern: pattern.type,
+        total: totalPrefs
+      })
+    })
+
+    console.log(`\n生成データ: ${allPreferences.length}件`)
+
+    // スタッフ別サマリ
+    console.log('\n=== スタッフ別サマリ ===')
+    console.log('社員（FULL_TIME）:')
+    summaryByStaff
+      .filter(s => s.type === 'FULL_TIME')
+      .forEach(s => {
+        console.log(`  [店舗${s.store_id}] ${s.name}: ${s.pattern} → ${s.total}件`)
+      })
+
+    console.log('\nアルバイト（PART_TIME）:')
+    summaryByStaff
+      .filter(s => s.type === 'PART_TIME')
+      .forEach(s => {
+        console.log(`  [店舗${s.store_id}] ${s.name}: ${s.pattern} → ${s.total}件`)
+      })
+
+    // 月別サマリ
+    console.log('\n=== 月別サマリ ===')
+    targetMonths.forEach(month => {
+      const monthPrefs = allPreferences.filter(p => p.preference_date.startsWith(`${targetYear}-${String(month).padStart(2, '0')}`))
+      const ngCount = monthPrefs.filter(p => p.is_ng).length
+      const shiftCount = monthPrefs.filter(p => !p.is_ng).length
+      console.log(`  ${month}月: ${monthPrefs.length}件 (NG: ${ngCount}, 希望: ${shiftCount})`)
+    })
+
+    // サンプルデータ表示
+    console.log('\n=== サンプルデータ（最初の10件） ===')
+    allPreferences.slice(0, 10).forEach(p => {
+      console.log(`  ${p.preference_date} | store:${p.store_id} | staff:${p.staff_id} | is_ng:${p.is_ng} | ${p.start_time || '-'}-${p.end_time || '-'}`)
+    })
+
+    if (isDryRun) {
+      console.log('\n[ドライラン] 実際の登録は行いません。')
+      console.log('登録するには --execute オプションを付けて実行してください。')
+    } else {
+      console.log('\n登録を開始します...')
+
+      if (shouldClear) {
+        console.log('既存データを削除中...')
+        const whereClause = buildWhereClause()
+        const deleteResult = await pool.query(`
+          DELETE FROM ops.shift_preferences WHERE ${whereClause}
+        `)
+        console.log(`  削除: ${deleteResult.rowCount}件`)
+      }
+
+      // バッチ挿入（1000件ずつ）
+      const batchSize = 1000
+      let inserted = 0
+
+      for (let i = 0; i < allPreferences.length; i += batchSize) {
+        const batch = allPreferences.slice(i, i + batchSize)
+
+        const values = batch.map((p, idx) => {
+          const base = idx * 8
+          return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7}, $${base + 8})`
+        }).join(', ')
+
+        const params = batch.flatMap(p => [
+          p.tenant_id, p.store_id, p.staff_id, p.preference_date,
+          p.is_ng, p.start_time, p.end_time, p.notes
+        ])
+
+        await pool.query(`
+          INSERT INTO ops.shift_preferences
+            (tenant_id, store_id, staff_id, preference_date, is_ng, start_time, end_time, notes)
+          VALUES ${values}
+        `, params)
+
+        inserted += batch.length
+        console.log(`  登録進捗: ${inserted}/${allPreferences.length}`)
+      }
+
+      console.log(`\n登録完了: ${inserted}件`)
+    }
+
+  } catch (error) {
+    console.error('エラー:', error)
+    process.exit(1)
+  } finally {
+    await pool.end()
+  }
+}
+
+main()

--- a/scripts/tools/generate-staff.mjs
+++ b/scripts/tools/generate-staff.mjs
@@ -1,0 +1,336 @@
+/**
+ * スタッフ一括生成ツール
+ *
+ * 使い方:
+ *   node scripts/tools/generate-staff.mjs --count 10 --dry-run
+ *   node scripts/tools/generate-staff.mjs --count 10 --store 6 --execute
+ *   node scripts/tools/generate-staff.mjs --count 5 --type PART_TIME --store 6,7 --execute
+ *   node scripts/tools/generate-staff.mjs --list
+ *   node scripts/tools/generate-staff.mjs --delete --staff 100,101,102
+ *
+ * オプション:
+ *   --count     生成人数（必須、--listと--delete以外）
+ *   --store     割り当て店舗ID（省略時: ランダム、複数指定可: 6,7,8）
+ *   --type      雇用形態（FULL_TIME, PART_TIME, CONTRACT）省略時: ランダム
+ *   --role      役職ID（省略時: デフォルト役職）
+ *   --list      現在のスタッフ一覧を表示
+ *   --delete    指定スタッフを削除
+ *   --staff     削除対象スタッフID（--deleteと一緒に使用、カンマ区切り）
+ *   --dry-run   生成データを表示するのみ（デフォルト）
+ *   --execute   実際にDBに登録する
+ */
+
+import pg from 'pg'
+const { Pool } = pg
+
+// 接続設定（STG環境）
+const pool = new Pool({
+  connectionString: 'postgresql://postgres:BWmHYBbEZqnptZRYmptockuomkHRWNPO@switchyard.proxy.rlwy.net:26491/railway',
+  ssl: { rejectUnauthorized: false }
+})
+
+// 引数パース
+const args = process.argv.slice(2)
+
+const getArg = (name) => {
+  const prefixed = args.find(a => a.startsWith(`--${name}=`))?.split('=')[1]
+  if (prefixed) return prefixed
+  const idx = args.indexOf(`--${name}`)
+  if (idx !== -1 && args[idx + 1] && !args[idx + 1].startsWith('--')) {
+    return args[idx + 1]
+  }
+  return null
+}
+
+const parseList = (str) => {
+  if (!str) return null
+  return str.split(',').map(s => s.trim())
+}
+
+const countArg = getArg('count')
+const storeArg = getArg('store')
+const typeArg = getArg('type')
+const roleArg = getArg('role')
+const staffArg = getArg('staff')
+const showList = args.includes('--list')
+const deleteMode = args.includes('--delete')
+const isDryRun = !args.includes('--execute')
+
+const TENANT_ID = 3 // テナントID
+
+// ダミーデータ
+const LAST_NAMES = ['佐藤', '鈴木', '高橋', '田中', '伊藤', '渡辺', '山本', '中村', '小林', '加藤',
+  '吉田', '山田', '佐々木', '山口', '松本', '井上', '木村', '林', '斎藤', '清水']
+const FIRST_NAMES = ['太郎', '花子', '一郎', '美咲', '健太', '愛', '翔太', '結衣', '大輔', '真由',
+  '優', '陽菜', '蓮', 'さくら', '颯太', '凛', '悠人', '葵', '大翔', '楓']
+
+const randomChoice = (arr) => arr[Math.floor(Math.random() * arr.length)]
+const randomInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min
+
+// ヘルプ表示
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`
+使い方: node generate-staff.mjs [オプション]
+
+生成:
+  --count <人数>     生成人数（必須）
+  --store <店舗ID>   割り当て店舗（例: 6, 6,7,8）
+  --type <雇用形態>  FULL_TIME, PART_TIME, CONTRACT
+  --role <役職ID>    役職ID
+
+一覧:
+  --list             現在のスタッフ一覧を表示
+
+削除:
+  --delete           スタッフを削除
+  --staff <ID>       削除対象ID（例: 100,101,102）
+
+アクション:
+  --dry-run          確認のみ（デフォルト）
+  --execute          実際に登録/削除
+
+例:
+  node generate-staff.mjs --count 10 --dry-run
+  node generate-staff.mjs --count 10 --store 6 --execute
+  node generate-staff.mjs --count 5 --type PART_TIME --store 6,7 --execute
+  node generate-staff.mjs --list
+  node generate-staff.mjs --delete --staff 100,101,102 --execute
+`)
+  process.exit(0)
+}
+
+// メイン処理
+async function main() {
+  console.log('='.repeat(60))
+  console.log(`スタッフ一括生成ツール`)
+  console.log('='.repeat(60))
+
+  try {
+    // 店舗一覧を取得
+    const storesResult = await pool.query(`
+      SELECT store_id, store_name FROM core.stores WHERE tenant_id = $1 ORDER BY store_id
+    `, [TENANT_ID])
+    const stores = storesResult.rows
+
+    // 役職一覧を取得
+    const rolesResult = await pool.query(`
+      SELECT role_id, role_name FROM core.roles WHERE tenant_id = $1 ORDER BY role_id
+    `, [TENANT_ID])
+    const roles = rolesResult.rows
+
+    // 一覧表示モード
+    if (showList) {
+      const staffResult = await pool.query(`
+        SELECT s.staff_id, s.name, s.staff_code, s.employment_type, s.is_active,
+               st.store_name, r.role_name
+        FROM hr.staff s
+        LEFT JOIN core.stores st ON s.store_id = st.store_id
+        LEFT JOIN core.roles r ON s.role_id = r.role_id
+        WHERE s.tenant_id = $1
+        ORDER BY s.store_id, s.staff_id
+      `, [TENANT_ID])
+
+      console.log(`\nスタッフ一覧: ${staffResult.rows.length}名\n`)
+      console.log('ID    | 名前           | コード     | 雇用形態   | 店舗       | 役職       | 状態')
+      console.log('-'.repeat(90))
+
+      staffResult.rows.forEach(s => {
+        const status = s.is_active ? '有効' : '無効'
+        console.log(
+          `${String(s.staff_id).padEnd(5)} | ` +
+          `${s.name.padEnd(12)} | ` +
+          `${(s.staff_code || '-').padEnd(10)} | ` +
+          `${s.employment_type.padEnd(10)} | ` +
+          `${(s.store_name || '-').padEnd(10)} | ` +
+          `${(s.role_name || '-').padEnd(10)} | ` +
+          `${status}`
+        )
+      })
+
+      // 集計
+      console.log('\n=== 集計 ===')
+      const byType = {}
+      staffResult.rows.forEach(s => {
+        byType[s.employment_type] = (byType[s.employment_type] || 0) + 1
+      })
+      Object.entries(byType).forEach(([type, count]) => {
+        console.log(`  ${type}: ${count}名`)
+      })
+
+      return
+    }
+
+    // 削除モード
+    if (deleteMode) {
+      const staffIds = parseList(staffArg)
+      if (!staffIds || staffIds.length === 0) {
+        console.error('エラー: --staff オプションで削除対象のスタッフIDを指定してください')
+        process.exit(1)
+      }
+
+      console.log(`\n削除対象: ${staffIds.join(', ')}`)
+
+      // 削除対象の確認
+      const targetResult = await pool.query(`
+        SELECT staff_id, name, employment_type FROM hr.staff
+        WHERE tenant_id = $1 AND staff_id IN (${staffIds.join(',')})
+      `, [TENANT_ID])
+
+      if (targetResult.rows.length === 0) {
+        console.log('削除対象のスタッフが見つかりません。')
+        await pool.end()
+        return
+      }
+
+      console.log('\n削除対象スタッフ:')
+      targetResult.rows.forEach(s => {
+        console.log(`  [${s.staff_id}] ${s.name} (${s.employment_type})`)
+      })
+
+      if (isDryRun) {
+        console.log('\n[ドライラン] 実際の削除は行いません。')
+        console.log('削除を実行するには --execute オプションを付けて実行してください。')
+      } else {
+        // 関連データを先に削除
+        const relatedTables = [
+          'ops.shifts',
+          'ops.shift_preferences',
+        ]
+
+        for (const table of relatedTables) {
+          const result = await pool.query(`
+            DELETE FROM ${table} WHERE tenant_id = $1 AND staff_id IN (${staffIds.join(',')})
+          `, [TENANT_ID])
+          if (result.rowCount > 0) {
+            console.log(`  ${table}: ${result.rowCount}件削除`)
+          }
+        }
+
+        // スタッフを削除
+        const deleteResult = await pool.query(`
+          DELETE FROM hr.staff WHERE tenant_id = $1 AND staff_id IN (${staffIds.join(',')})
+        `, [TENANT_ID])
+        console.log(`\nスタッフ削除: ${deleteResult.rowCount}名`)
+      }
+
+      return
+    }
+
+    // 生成モード
+    if (!countArg) {
+      console.error('エラー: --count オプションで生成人数を指定してください')
+      console.error('使い方を確認するには --help を実行してください')
+      process.exit(1)
+    }
+
+    const count = parseInt(countArg)
+    const targetStores = parseList(storeArg)?.map(Number) || stores.map(s => s.store_id)
+    const targetType = typeArg || null
+
+    console.log(`生成人数: ${count}名`)
+    console.log(`対象店舗: ${targetStores.join(', ')}`)
+    console.log(`雇用形態: ${targetType || 'ランダム'}`)
+    console.log(`モード: ${isDryRun ? 'ドライラン（確認のみ）' : '実行（登録）'}`)
+    console.log('='.repeat(60))
+
+    // 既存の最大staff_codeを取得（STAFF_XXX形式）
+    const maxCodeResult = await pool.query(`
+      SELECT MAX(CAST(SUBSTRING(staff_code FROM 7) AS INTEGER)) as max_num
+      FROM hr.staff
+      WHERE tenant_id = $1 AND staff_code LIKE 'STAFF_%'
+    `, [TENANT_ID])
+    let nextCodeNum = (maxCodeResult.rows[0].max_num || 0) + 1
+
+    // スタッフデータを生成
+    const newStaff = []
+    const employmentTypes = ['FULL_TIME', 'PART_TIME', 'CONTRACT']
+
+    for (let i = 0; i < count; i++) {
+      const name = `${randomChoice(LAST_NAMES)} ${randomChoice(FIRST_NAMES)}`
+      const staffCode = `STAFF_${String(nextCodeNum++).padStart(3, '0')}`
+      const storeId = randomChoice(targetStores)
+      const employmentType = targetType || randomChoice(employmentTypes)
+      const roleId = roleArg ? parseInt(roleArg) : (roles.length > 0 ? roles[0].role_id : null)
+
+      newStaff.push({
+        tenant_id: TENANT_ID,
+        name,
+        staff_code: staffCode,
+        store_id: storeId,
+        employment_type: employmentType,
+        role_id: roleId,
+        hire_date: new Date().toISOString().split('T')[0], // 今日の日付
+        is_active: true,
+      })
+    }
+
+    // サマリ表示
+    console.log('\n=== 生成データサマリ ===')
+    const byType = {}
+    const byStore = {}
+    newStaff.forEach(s => {
+      byType[s.employment_type] = (byType[s.employment_type] || 0) + 1
+      byStore[s.store_id] = (byStore[s.store_id] || 0) + 1
+    })
+
+    console.log('\n雇用形態別:')
+    Object.entries(byType).forEach(([type, cnt]) => {
+      console.log(`  ${type}: ${cnt}名`)
+    })
+
+    console.log('\n店舗別:')
+    Object.entries(byStore).forEach(([storeId, cnt]) => {
+      const store = stores.find(s => s.store_id === parseInt(storeId))
+      console.log(`  [${storeId}] ${store?.store_name || '不明'}: ${cnt}名`)
+    })
+
+    // サンプル表示
+    console.log('\n=== サンプルデータ（最初の10件） ===')
+    newStaff.slice(0, 10).forEach(s => {
+      const store = stores.find(st => st.store_id === s.store_id)
+      console.log(`  ${s.staff_code} | ${s.name} | ${s.employment_type} | ${store?.store_name || '不明'}`)
+    })
+
+    if (isDryRun) {
+      console.log('\n[ドライラン] 実際の登録は行いません。')
+      console.log('登録を実行するには --execute オプションを付けて実行してください。')
+    } else {
+      console.log('\n登録を開始します...')
+
+      // バッチ挿入
+      const batchSize = 100
+      let inserted = 0
+
+      for (let i = 0; i < newStaff.length; i += batchSize) {
+        const batch = newStaff.slice(i, i + batchSize)
+
+        const values = batch.map((_, idx) => {
+          const base = idx * 7
+          return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7})`
+        }).join(', ')
+
+        const params = batch.flatMap(s => [
+          s.tenant_id, s.name, s.staff_code, s.store_id, s.employment_type, s.role_id, s.hire_date
+        ])
+
+        await pool.query(`
+          INSERT INTO hr.staff (tenant_id, name, staff_code, store_id, employment_type, role_id, hire_date)
+          VALUES ${values}
+        `, params)
+
+        inserted += batch.length
+        console.log(`  登録進捗: ${inserted}/${newStaff.length}`)
+      }
+
+      console.log(`\n登録完了: ${inserted}名`)
+    }
+
+  } catch (error) {
+    console.error('エラー:', error)
+    process.exit(1)
+  } finally {
+    await pool.end()
+  }
+}
+
+main()

--- a/scripts/tools/reset-data.mjs
+++ b/scripts/tools/reset-data.mjs
@@ -1,0 +1,217 @@
+/**
+ * データリセットツール
+ *
+ * 使い方:
+ *   node scripts/tools/reset-data.mjs --dry-run
+ *   node scripts/tools/reset-data.mjs --year 2025 --month 1 --execute
+ *   node scripts/tools/reset-data.mjs --year 2025 --tables shifts,shift_preferences --execute
+ *   node scripts/tools/reset-data.mjs --all --execute
+ *
+ * オプション:
+ *   --year      対象年（省略時: 全期間）
+ *   --month     対象月（省略時: 指定年の全月）
+ *   --store     対象店舗ID（省略時: 全店舗）
+ *   --tables    対象テーブル（カンマ区切り、省略時: shifts,shift_preferences,shift_plans）
+ *   --all       全データ削除（マスタ以外）
+ *   --dry-run   削除前に確認のみ（デフォルト）
+ *   --execute   実際に削除する
+ */
+
+import pg from 'pg'
+const { Pool } = pg
+
+// 接続設定（STG環境）
+const pool = new Pool({
+  connectionString: 'postgresql://postgres:BWmHYBbEZqnptZRYmptockuomkHRWNPO@switchyard.proxy.rlwy.net:26491/railway',
+  ssl: { rejectUnauthorized: false }
+})
+
+// 引数パース
+const args = process.argv.slice(2)
+
+const getArg = (name) => {
+  const prefixed = args.find(a => a.startsWith(`--${name}=`))?.split('=')[1]
+  if (prefixed) return prefixed
+  const idx = args.indexOf(`--${name}`)
+  if (idx !== -1 && args[idx + 1] && !args[idx + 1].startsWith('--')) {
+    return args[idx + 1]
+  }
+  return null
+}
+
+const yearArg = getArg('year')
+const monthArg = getArg('month')
+const storeArg = getArg('store')
+const tablesArg = getArg('tables')
+const deleteAll = args.includes('--all')
+const isDryRun = !args.includes('--execute')
+
+const TENANT_ID = 3 // テナントID
+
+// 対象テーブル
+const DEFAULT_TABLES = ['shifts', 'shift_preferences', 'shift_plans']
+const ALL_DATA_TABLES = [
+  'ops.shifts',
+  'ops.shift_preferences',
+  'ops.shift_plans',
+  'ops.notifications',
+  'hr.payroll',
+]
+
+const targetTables = tablesArg ? tablesArg.split(',').map(t => t.trim()) : DEFAULT_TABLES
+
+// ヘルプ表示
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`
+使い方: node reset-data.mjs [オプション]
+
+フィルタ:
+  --year <年>        対象年（例: 2025）
+  --month <月>       対象月（例: 1）
+  --store <店舗ID>   対象店舗（例: 6）
+  --tables <テーブル> 対象テーブル（カンマ区切り）
+                     使用可能: shifts, shift_preferences, shift_plans
+
+特殊:
+  --all              全データ削除（マスタ以外）
+
+アクション:
+  --dry-run          確認のみ（デフォルト）
+  --execute          実際に削除
+
+例:
+  node reset-data.mjs --dry-run
+  node reset-data.mjs --year 2025 --month 1 --execute
+  node reset-data.mjs --year 2025 --tables shifts,shift_preferences --execute
+  node reset-data.mjs --all --execute
+`)
+  process.exit(0)
+}
+
+// メイン処理
+async function main() {
+  console.log('='.repeat(60))
+  console.log(`データリセットツール`)
+  console.log('='.repeat(60))
+  console.log(`対象年: ${yearArg || '全期間'}`)
+  console.log(`対象月: ${monthArg || '全月'}`)
+  console.log(`対象店舗: ${storeArg || '全店舗'}`)
+  console.log(`対象テーブル: ${deleteAll ? 'ALL (マスタ以外)' : targetTables.join(', ')}`)
+  console.log(`モード: ${isDryRun ? 'ドライラン（確認のみ）' : '実行（削除）'}`)
+  console.log('='.repeat(60))
+
+  try {
+    // 現在のデータ件数を表示
+    console.log('\n=== 現在のデータ件数 ===')
+
+    const tables = deleteAll ? ALL_DATA_TABLES : targetTables.map(t => {
+      if (t === 'shifts') return 'ops.shifts'
+      if (t === 'shift_preferences') return 'ops.shift_preferences'
+      if (t === 'shift_plans') return 'ops.shift_plans'
+      return t
+    })
+
+    const counts = {}
+    for (const table of tables) {
+      const result = await pool.query(`SELECT COUNT(*) FROM ${table} WHERE tenant_id = $1`, [TENANT_ID])
+      counts[table] = parseInt(result.rows[0].count)
+      console.log(`  ${table}: ${counts[table]}件`)
+    }
+
+    // 削除対象件数を計算
+    console.log('\n=== 削除対象 ===')
+
+    const deleteTargets = {}
+
+    for (const table of tables) {
+      let conditions = [`tenant_id = ${TENANT_ID}`]
+
+      if (yearArg) {
+        if (table.includes('shift_preferences')) {
+          conditions.push(`EXTRACT(YEAR FROM preference_date) = ${yearArg}`)
+          if (monthArg) {
+            conditions.push(`EXTRACT(MONTH FROM preference_date) = ${monthArg}`)
+          }
+        } else if (table.includes('shifts')) {
+          conditions.push(`EXTRACT(YEAR FROM shift_date) = ${yearArg}`)
+          if (monthArg) {
+            conditions.push(`EXTRACT(MONTH FROM shift_date) = ${monthArg}`)
+          }
+        } else if (table.includes('shift_plans')) {
+          conditions.push(`plan_year = ${yearArg}`)
+          if (monthArg) {
+            conditions.push(`plan_month = ${monthArg}`)
+          }
+        }
+      }
+
+      if (storeArg && (table.includes('shifts') || table.includes('shift_preferences') || table.includes('shift_plans'))) {
+        conditions.push(`store_id = ${storeArg}`)
+      }
+
+      const whereClause = conditions.join(' AND ')
+      const countResult = await pool.query(`SELECT COUNT(*) FROM ${table} WHERE ${whereClause}`)
+      const targetCount = parseInt(countResult.rows[0].count)
+
+      deleteTargets[table] = {
+        count: targetCount,
+        whereClause,
+      }
+
+      console.log(`  ${table}: ${targetCount}件`)
+    }
+
+    // 合計
+    const totalToDelete = Object.values(deleteTargets).reduce((sum, t) => sum + t.count, 0)
+    console.log(`\n  合計: ${totalToDelete}件`)
+
+    if (totalToDelete === 0) {
+      console.log('\n削除対象のデータがありません。')
+      await pool.end()
+      return
+    }
+
+    if (isDryRun) {
+      console.log('\n[ドライラン] 実際の削除は行いません。')
+      console.log('削除を実行するには --execute オプションを付けて実行してください。')
+    } else {
+      console.log('\n削除を実行します...')
+
+      // 削除順序を考慮（外部キー制約がある場合）
+      const deleteOrder = [
+        'ops.shifts',
+        'ops.shift_preferences',
+        'ops.shift_plans',
+        'ops.notifications',
+        'hr.payroll',
+      ]
+
+      for (const table of deleteOrder) {
+        if (!deleteTargets[table]) continue
+
+        const { whereClause, count } = deleteTargets[table]
+        if (count === 0) continue
+
+        const result = await pool.query(`DELETE FROM ${table} WHERE ${whereClause}`)
+        console.log(`  ${table}: ${result.rowCount}件削除`)
+      }
+
+      console.log('\n削除完了')
+
+      // 削除後の件数を表示
+      console.log('\n=== 削除後のデータ件数 ===')
+      for (const table of tables) {
+        const result = await pool.query(`SELECT COUNT(*) FROM ${table} WHERE tenant_id = $1`, [TENANT_ID])
+        console.log(`  ${table}: ${result.rows[0].count}件`)
+      }
+    }
+
+  } catch (error) {
+    console.error('エラー:', error)
+    process.exit(1)
+  } finally {
+    await pool.end()
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary
- 開発・テスト効率化のためのCLIツール群を追加 (#86)
- アプリケーションコードへの変更なし（scriptsディレクトリのみ）

## 含まれる変更
- PR #146: feat: 開発・テスト用データ生成ツールを追加

## 追加されたツール
| ツール | 機能 |
|--------|------|
| `generate-staff.mjs` | スタッフ一括生成 |
| `generate-random-preferences.mjs` | 希望シフトのランダム生成 |
| `generate-first-plan.mjs` | 第1案シフトの生成 |
| `generate-actual-shifts.mjs` | 実績シフト生成 |
| `reset-data.mjs` | テストデータのリセット |
| `README.html` | 使用ガイド |

## Test plan
- [x] CIチェック通過確認
- [x] アプリケーションコードへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)