### PR TITLE
fix: deadline-settings APIのカラム名をDBスキーマに合わせて修正

### DIFF
--- a/backend/src/routes/liff.js
+++ b/backend/src/routes/liff.js
@@ -338,8 +338,7 @@ router.get('/check-link', verifyLineToken, async (req, res) => {
         `SELECT
           employment_type,
           deadline_day,
-          deadline_hour,
-          deadline_minute,
+          deadline_time,
           is_enabled,
           description
          FROM core.shift_deadline_settings


### PR DESCRIPTION
## Summary
- `/api/liff/deadline-settings` APIのSQLクエリで参照しているカラム名を修正
- `deadline_hour`/`deadline_minute` → `deadline_time` に変更
- DBスキーマ（`core.shift_deadline_settings`）とフロントエンド（LIFF）が期待するカラム名に統一

## 問題の原因
- DBスキーマでは `deadline_time VARCHAR(5)` として定義されている
- フロントエンドは `deadline_time` を期待している
- しかしAPIは存在しない `deadline_hour`/`deadline_minute` を参照しようとしていた
- これによりSQLエラーが発生し、期限設定が取得できず、期限チェック機能が動作しなかった

## 影響範囲
| コンポーネント | 変更前 | 変更後 |
|---------------|--------|--------|
| DBスキーマ | `deadline_time` | 変更なし |
| フロントエンド | `deadline_time`を期待 | 変更なし |
| バックエンドAPI | `deadline_hour`/`deadline_minute` | `deadline_time` ✅ |

## Test plan
- [ ] LIFFでシフト希望入力画面を開き、期限情報が正しく表示されることを確認
- [ ] 期限を過ぎた月のシフト入力ができないことを確認
- [ ] ブラウザコンソールで `deadlineSettingsMap` にデータが入っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)