### PR TITLE
Release: 雇用形態名修正（契約社員→業務委託）

### DIFF
--- a/scripts/database/ddl/schema.sql
+++ b/scripts/database/ddl/schema.sql
@@ -129,7 +129,7 @@ CREATE TABLE IF NOT EXISTS core.shift_deadline_settings (
 );
 
 COMMENT ON TABLE core.shift_deadline_settings IS 'シフト希望入力締切設定（契約形態別）。入力開始は第1案作成完了時';
-COMMENT ON COLUMN core.shift_deadline_settings.employment_type IS '契約形態（FULL_TIME=正社員、PART_TIME=アルバイト・パート、CONTRACT=契約社員、TEMPORARY=派遣社員）';
+COMMENT ON COLUMN core.shift_deadline_settings.employment_type IS '契約形態（FULL_TIME=正社員、PART_TIME=アルバイト・パート、CONTRACT=業務委託、TEMPORARY=派遣社員）';
 COMMENT ON COLUMN core.shift_deadline_settings.deadline_day IS 'シフト希望入力締切日（N-1月の1-31日）';
 COMMENT ON COLUMN core.shift_deadline_settings.deadline_time IS '締切時刻（"HH:MM"形式、例: "23:59", "18:00"）';
 COMMENT ON COLUMN core.shift_deadline_settings.is_enabled IS '期限チェック有効/無効フラグ';

--- a/scripts/database/dml/01_core_master.sql
+++ b/scripts/database/dml/01_core_master.sql
@@ -37,9 +37,9 @@ INSERT INTO core.employment_types (tenant_id, employment_code, employment_name, 
 VALUES (3, 'PART_TIME', 'アルバイト', 'HOURLY', true)
 ON CONFLICT DO NOTHING;
 
--- 契約社員
+-- 業務委託
 INSERT INTO core.employment_types (tenant_id, employment_code, employment_name, payment_type, is_active)
-VALUES (3, 'CONTRACT', '契約社員', 'MONTHLY', true)
+VALUES (3, 'CONTRACT', '業務委託', 'MONTHLY', true)
 ON CONFLICT DO NOTHING;
 
 -- 派遣社員
@@ -242,12 +242,12 @@ SET
     description = EXCLUDED.description,
     updated_at = CURRENT_TIMESTAMP;
 
--- 契約社員（CONTRACT）の期限設定
+-- 業務委託（CONTRACT）の期限設定
 -- 入力開始: 第1案作成完了時、締切: N-1月10日12:00
 INSERT INTO core.shift_deadline_settings
   (tenant_id, employment_type, deadline_day, deadline_time, is_enabled, description)
 VALUES
-  (3, 'CONTRACT', 10, '12:00', true, '契約社員のシフト希望締切（第1案作成完了～N-1月10日12:00）')
+  (3, 'CONTRACT', 10, '12:00', true, '業務委託のシフト希望締切（第1案作成完了～N-1月10日12:00）')
 ON CONFLICT (tenant_id, employment_type) DO UPDATE
 SET
     deadline_day = EXCLUDED.deadline_day,


### PR DESCRIPTION
## Summary
雇用形態マスターの表示名修正をmainにリリース

## 含まれるPR
- #172: 雇用形態名を「契約社員」から「業務委託」に変更

## 変更内容
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| employment_code | CONTRACT | CONTRACT（変更なし）|
| employment_name | 契約社員 | 業務委託 |

## 対象ファイル
- `scripts/database/dml/01_core_master.sql`
- `scripts/database/ddl/schema.sql`

## 注意事項
- 既存DBデータには影響なし（ファイル変更のみ）
- 本番DBを更新する場合は別途UPDATE文を実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)