### PR TITLE
feat: シフト承認時にLINE通知APIを呼び出し（#104）

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,3 +35,9 @@ DEMO_PLAN_ID=4
 DEMO_STAFF_ID=5
 DEMO_YEAR=2024
 DEMO_MONTH=10
+
+# LIFF Backend URL（LINE通知送信用）
+# LOCAL: http://localhost:3001
+# STG: https://shift-scheduler-ai-liff-backend-staging-staging.up.railway.app
+# PRD: https://shift-scheduler-ai-liff-production.up.railway.app
+LIFF_BACKEND_URL=http://localhost:3001


### PR DESCRIPTION
## Summary
- 第1案承認時にLIFF BackendのAPIを呼び出してLINE通知を送信
- 第2案承認時（ステータスAPPROVED変更時）にシフト確定通知を送信
- LIFF_BACKEND_URL環境変数を追加

## 関連Issue
- #104 承認通知

## 依存関係
- ⚠️ **先に shift-scheduler-ai-liff の PR #26 をマージする必要があります**
- マージ後、Railway環境変数を設定してください（下記参照）

## 変更ファイル
- `backend/src/routes/shifts.js` - 承認処理にLINE通知API呼び出し追加
- `backend/.env.example` - LIFF_BACKEND_URL追加

## 環境変数設定（Railway）

### shift-scheduler-ai 側
| 環境 | 変数名 | 値 |
|-----|-------|-----|
| STG | LIFF_BACKEND_URL | `https://shift-scheduler-ai-liff-backend-staging-staging.up.railway.app` |
| PRD | LIFF_BACKEND_URL | `https://shift-scheduler-ai-liff-production.up.railway.app` |

### shift-scheduler-ai-liff 側
| 環境 | 変数名 | 値 | 説明 |
|-----|-------|-----|------|
| STG | NOTIFICATION_ENABLED | `true` または `false` | 通知ON/OFF制御 |
| PRD | NOTIFICATION_ENABLED | `true` または `false` | 通知ON/OFF制御 |

## Test plan
- [ ] shift-scheduler-ai-liff PR #26 がマージされていることを確認
- [ ] Railway環境変数をすべて設定
- [ ] 第1案承認時にLINEグループに通知が届くことを確認
- [ ] 第2案承認時にLINEグループに通知が届くことを確認
- [ ] LIFF_BACKEND_URL未設定時は通知スキップ（承認は成功）
- [ ] NOTIFICATION_ENABLED=false で通知がスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)