### PR TITLE
feat: 第二案の店舗別スクリーンショット機能を追加

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,6 +51,7 @@
         "framer-motion": "^12.15.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.510.0",
+        "modern-screenshot": "^4.6.7",
         "next-themes": "^0.4.6",
         "openai": "^6.1.0",
         "papaparse": "^5.5.3",
@@ -7683,6 +7684,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/modern-screenshot": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/modern-screenshot/-/modern-screenshot-4.6.7.tgz",
+      "integrity": "sha512-0GhgI6i6le4AhKzCvLYjwEmsP47kTsX45iT5yuAzsLTi/7i3Rjxe8fbH2VjGJLuyOThwsa0CdQAPd4auoEtsZg=="
     },
     "node_modules/motion-dom": {
       "version": "12.23.23",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,6 +79,7 @@
     "framer-motion": "^12.15.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.510.0",
+    "modern-screenshot": "^4.6.7",
     "next-themes": "^0.4.6",
     "openai": "^6.1.0",
     "papaparse": "^5.5.3",


### PR DESCRIPTION
## Summary
- 第二案編集画面に「店舗別スクショ」ボタンを追加
- 選択された店舗ごとにシフトテーブルをPNG形式でダウンロード
- modern-screenshotライブラリを使用（oklchカラー対応）
- ファイル名形式: `{year}年{month}月_{店舗名}.png`

## Test plan
- [x] 第二案編集画面で「店舗別スクショ」ボタンが表示される
- [x] 複数店舗選択時、各店舗ごとにPNGがダウンロードされる
- [x] ファイル名が正しい形式になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)