### PR TITLE
fix: シフトコピーの週番号計算ロジックを修正

### DIFF
--- a/backend/src/routes/shifts.js
+++ b/backend/src/routes/shifts.js
@@ -698,11 +698,21 @@ router.post('/plans/generate', async (req, res) => {
     const copiedShifts = [];
 
     // 週番号と曜日を計算するヘルパー関数
+    // 「その月の第何X曜日か」を計算する（例: 第2月曜日、第3金曜日など）
     const getWeekInfo = (date) => {
-      const firstDay = new Date(date.getFullYear(), date.getMonth(), 1);
+      const year = date.getFullYear();
+      const month = date.getMonth();
       const dayOfWeek = date.getDay(); // 0=日, 1=月, ...
       const dayOfMonth = date.getDate();
-      const weekNumber = Math.ceil((dayOfMonth + firstDay.getDay()) / 7);
+
+      // その月で同じ曜日が何回目かを数える
+      let weekNumber = 0;
+      for (let d = 1; d <= dayOfMonth; d++) {
+        if (new Date(year, month, d).getDay() === dayOfWeek) {
+          weekNumber++;
+        }
+      }
+
       return { weekNumber, dayOfWeek };
     };
 
@@ -3179,12 +3189,21 @@ router.post('/plans/copy-from-previous-all-stores', async (req, res) => {
             // 事前取得済みのシフトからフィルタリング（クエリ不要）
             const sourceShiftsRows = allSourceShifts.filter(s => s.plan_id === sourcePlan.plan_id);
 
-            // 曜日ベースでコピー（既存ロジックと同じ）
+            // 曜日ベースでコピー（「その月の第何X曜日か」を計算）
             const getWeekInfo = (date) => {
-              const firstDay = new Date(date.getFullYear(), date.getMonth(), 1);
+              const year = date.getFullYear();
+              const month = date.getMonth();
               const dayOfWeek = date.getDay();
               const dayOfMonth = date.getDate();
-              const weekNumber = Math.ceil((dayOfMonth + firstDay.getDay()) / 7);
+
+              // その月で同じ曜日が何回目かを数える
+              let weekNumber = 0;
+              for (let d = 1; d <= dayOfMonth; d++) {
+                if (new Date(year, month, d).getDay() === dayOfWeek) {
+                  weekNumber++;
+                }
+              }
+
               return { weekNumber, dayOfWeek };
             };
 


### PR DESCRIPTION
## Summary

- シフトコピー時の週番号計算ロジックにバグがあり、前月第2案から翌月第1案へのコピーが正しく行われていなかった
- 「カレンダー行」ベースの計算を「その月の第何X曜日か」に修正

## 問題の詳細

### 修正前のロジック
```javascript
const weekNumber = Math.ceil((dayOfMonth + firstDay.getDay()) / 7);
```
これは日曜始まりのカレンダーで「何行目か」を返すため、例えば：
- 11/2（日）→ 第2週（本来は第1日曜日）
- 11/14（金）→ 第3週（本来は第2金曜日）

### 修正後のロジック
```javascript
let weekNumber = 0;
for (let d = 1; d <= dayOfMonth; d++) {
  if (new Date(year, month, d).getDay() === dayOfWeek) {
    weekNumber++;
  }
}
```
正しく「その月の第何X曜日か」を計算。

## 影響

- 11月第2案 → 12月第1案のコピーで一致率が82.1%だった（5件の不一致）
- 12月第2案 → 1月第1案は100%一致（修正前から偶然一致していた）

## Test plan

- [ ] 単体テスト追加
- [ ] 11月→12月のシフトコピーが正しく動作することを確認
- [ ] 既存のシフトコピー機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)