### PR TITLE
feat: 本番DBの定期バックアップ機能を追加

### DIFF
--- a/.github/workflows/db-backup-to-sharepoint.yml
+++ b/.github/workflows/db-backup-to-sharepoint.yml
@@ -1,0 +1,104 @@
+# ⚠️ このワークフローは現在無効化されています
+# SharePointの承認が降りたら、下記の手順で有効化してください：
+# 1. Azure ADアプリケーションを登録（詳細は scripts/backup/README.md 参照）
+# 2. GitHub Secretsを設定
+# 3. このファイルの先頭のコメントブロックを削除
+#
+# 🔧 必要なGitHub Secrets:
+#   - DATABASE_URL_PRODUCTION: 本番DBのURL
+#   - AZURE_TENANT_ID: Azure ADテナントID
+#   - AZURE_CLIENT_ID: Azure ADクライアントID
+#   - AZURE_CLIENT_SECRET: Azure ADクライアントシークレット
+#   - SHAREPOINT_SITE_URL: SharePointサイトURL
+#   - SHAREPOINT_FOLDER_PATH: 保存先フォルダパス
+
+# 以下のコメントアウトを解除して有効化 ↓↓↓
+
+# name: Database Backup to SharePoint
+#
+# on:
+#   schedule:
+#     # 毎月1日と15日の午前3時（UTC 18:00 = JST 03:00）に実行
+#     - cron: '0 18 1,15 * *'
+#   workflow_dispatch:  # 手動実行も可能
+#
+# jobs:
+#   backup:
+#     runs-on: ubuntu-latest
+#     timeout-minutes: 30
+#
+#     steps:
+#       - name: チェックアウト
+#         uses: actions/checkout@v4
+#
+#       - name: Node.js のセットアップ
+#         uses: actions/setup-node@v4
+#         with:
+#           node-version: '18'
+#
+#       - name: PostgreSQL クライアントのインストール
+#         run: |
+#           sudo apt-get update
+#           sudo apt-get install -y postgresql-client
+#
+#       - name: バックアップファイル名の設定
+#         id: backup-file
+#         run: |
+#           TIMESTAMP=$(date +%Y-%m-%d)
+#           BACKUP_FILE="db-backup-${TIMESTAMP}.sql"
+#           echo "filename=${BACKUP_FILE}" >> $GITHUB_OUTPUT
+#           echo "timestamp=${TIMESTAMP}" >> $GITHUB_OUTPUT
+#
+#       - name: データベースバックアップの作成
+#         env:
+#           DATABASE_URL: ${{ secrets.DATABASE_URL_PRODUCTION }}
+#         run: |
+#           echo "🚀 バックアップを作成中..."
+#           pg_dump "$DATABASE_URL" > ${{ steps.backup-file.outputs.filename }}
+#
+#           # ファイルサイズを確認
+#           FILE_SIZE=$(du -h ${{ steps.backup-file.outputs.filename }} | cut -f1)
+#           echo "✅ バックアップ完了: ${FILE_SIZE}"
+#           echo "file_size=${FILE_SIZE}" >> $GITHUB_OUTPUT
+#
+#       - name: バックアップファイルの圧縮
+#         run: |
+#           echo "📦 ファイルを圧縮中..."
+#           gzip ${{ steps.backup-file.outputs.filename }}
+#
+#           # 圧縮後のファイルサイズを確認
+#           COMPRESSED_SIZE=$(du -h ${{ steps.backup-file.outputs.filename }}.gz | cut -f1)
+#           echo "✅ 圧縮完了: ${COMPRESSED_SIZE}"
+#
+#       - name: SharePointへのアップロード
+#         env:
+#           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+#           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+#           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+#           SHAREPOINT_SITE_URL: ${{ secrets.SHAREPOINT_SITE_URL }}
+#           SHAREPOINT_FOLDER_PATH: ${{ secrets.SHAREPOINT_FOLDER_PATH }}
+#           BACKUP_FILE: ${{ steps.backup-file.outputs.filename }}.gz
+#         run: |
+#           echo "📤 SharePointにアップロード中..."
+#           node scripts/backup/upload-to-sharepoint.mjs
+#
+#       - name: バックアップ完了通知
+#         if: success()
+#         run: |
+#           echo "✅ バックアップが正常に完了しました"
+#           echo "📅 日時: $(date)"
+#           echo "📂 ファイル名: ${{ steps.backup-file.outputs.filename }}.gz"
+#           echo "📊 ファイルサイズ: ${{ steps.backup-file.outputs.file_size }}"
+#
+#       - name: エラー通知
+#         if: failure()
+#         run: |
+#           echo "❌ バックアップに失敗しました"
+#           echo "📅 日時: $(date)"
+#           echo "🔍 詳細はワークフローログを確認してください"
+
+# 🚧 Phase 2 実装予定
+# - Slack/メール通知機能
+# - バックアップの世代管理（古いファイルの自動削除）
+# - バックアップの整合性チェック
+# - リストア手順の自動化

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,9 @@ frontend/public/data/generated/*
 # Test coverage
 coverage
 .nyc_output
+
+# Database backups
+backups
+*.sql
+*.dump
+*.dmp

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test:schema:keep": "node scripts/test_schema_crud_no_cleanup.mjs",
     "db:cleanup": "node scripts/cleanup_test_data.mjs",
     "db:setup": "node scripts/run_db_setup.mjs",
+    "bk:prod": "node scripts/backup/backup-db.mjs",
+      "_comment": "localでproduction環境のdmpを取得する。暫定対応用なので後で正式な方法に切り替える。使い方は'shift-scheduler-ai/scripts/backup/README.md'参照",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/backup/README.md
+++ b/scripts/backup/README.md
@@ -1,0 +1,477 @@
+# データベースバックアップガイド
+
+本番環境のデータベースを定期的にバックアップするための仕組みです。
+
+## 📋 目次
+
+- [Phase 1: ローカル手動実行（現在）](#phase-1-ローカル手動実行現在)
+- [Phase 2: SharePoint自動アップロード（将来）](#phase-2-sharepoint自動アップロード将来)
+- [移行手順](#移行手順)
+- [トラブルシューティング](#トラブルシューティング)
+
+---
+
+## Phase 1: ローカル手動実行（現在）
+
+**目的:** SharePointの承認待ちの間、手動でバックアップを取得してローカルに保存
+
+### 前提条件
+
+1. **PostgreSQLクライアントのインストール**
+
+   ```bash
+   # macOS
+   brew install postgresql
+
+   # Ubuntu/Debian
+   sudo apt-get install postgresql-client
+
+   # Windows
+   # https://www.postgresql.org/download/windows/ からインストール
+   ```
+
+2. **本番環境のDATABASE_URLの取得**
+   - Railwayダッシュボードにアクセス
+   - Production環境のPostgreSQLサービスを選択
+   - `DATABASE_URL` をコピー
+
+### 使い方
+
+#### 方法1: 環境変数ファイルを使う（推奨）
+
+1. **プロジェクトルートの `.env` ファイル**に本番DBのURLを追加：
+
+   **ファイルパス**: `shift-scheduler-ai/.env`（プロジェクトルート）
+
+   ```
+   shift-scheduler-ai/          ← プロジェクトルート
+   ├── .env                     ← ここに設定！
+   ├── backend/
+   │   └── .env                 ← ここではない
+   ├── frontend/
+   │   └── .env                 ← ここでもない
+   ├── scripts/
+   │   └── backup/
+   └── package.json
+   ```
+
+   ```bash
+   # shift-scheduler-ai/.env
+   DATABASE_URL_PRODUCTION=postgresql://user:password@host:port/database
+   ```
+
+   ⚠️ **重要**: `backend/.env` や `frontend/.env` ではなく、**プロジェクトルートの `.env`** に設定してください。
+
+2. バックアップを実行：
+
+   ```bash
+   npm run bk:prod
+   ```
+
+#### 方法2: コマンド実行時に指定
+
+```bash
+DATABASE_URL_PRODUCTION="postgresql://user:password@host:port/database" npm run bk:prod
+```
+
+### バックアップファイルの保存場所
+
+バックアップファイルは `backups/` ディレクトリに**タイムスタンプごとのフォルダ**として保存され、各フォルダ内に**スキーマごとのdmpファイル**が格納されます：
+
+```
+shift-scheduler-ai/
+├── backups/
+│   ├── 2025-12-22-120530/              ← タイムスタンプフォルダ (YYYY-MM-DD-HHMMSS)
+│   │   ├── core.dmp                    ← core スキーマ
+│   │   ├── hr.dmp                      ← hr スキーマ
+│   │   ├── ops.dmp                     ← ops スキーマ
+│   │   └── analytics.dmp               ← analytics スキーマ
+│   ├── 2025-12-01-100000/              ← 前回のバックアップ
+│   │   ├── core.dmp
+│   │   ├── hr.dmp
+│   │   ├── ops.dmp
+│   │   └── analytics.dmp
+│   └── ...
+```
+
+**フォルダ名の形式:**
+- `YYYY-MM-DD-HHMMSS` 形式のタイムスタンプ
+- 例: `2025-12-22-120530` = 2025年12月22日 12時05分30秒
+
+**バックアップ対象のスキーマ:**
+- `core` - コアテーブル
+- `hr` - 人事関連テーブル
+- `ops` - オペレーション関連テーブル
+- `analytics` - 分析関連テーブル
+
+**ファイル形式:**
+- `.dmp` 形式（PostgreSQLカスタムフォーマット）
+- `pg_restore` コマンドでリストア可能
+
+### 実行結果の例
+
+```bash
+$ npm run bk:prod
+
+🚀 データベースバックアップを開始します...
+📅 日時: 2025/12/22 12:05:30
+📋 対象スキーマ: core, hr, ops, analytics
+📂 保存フォルダ: 2025-12-22-120530
+
+📁 バックアップディレクトリを作成: /path/to/backups/2025-12-22-120530
+💾 スキーマ「core」をバックアップ中...
+✅ core: 45.23 MB
+💾 スキーマ「hr」をバックアップ中...
+✅ hr: 32.15 MB
+💾 スキーマ「ops」をバックアップ中...
+✅ ops: 28.67 MB
+💾 スキーマ「analytics」をバックアップ中...
+✅ analytics: 19.38 MB
+
+📊 バックアップ結果サマリー:
+
+✅ 成功: 4/4 スキーマ
+   - core: 45.23 MB
+   - hr: 32.15 MB
+   - ops: 28.67 MB
+   - analytics: 19.38 MB
+
+📍 保存場所: /path/to/backups/2025-12-22-120530
+
+📋 既存のバックアップ:
+
+  ✨ 2025-12-22-120530 [最新]
+     合計: 125.43 MB (4 スキーマ)
+     - core: 45.23 MB
+     - hr: 32.15 MB
+     - ops: 28.67 MB
+     - analytics: 19.38 MB
+
+     2025-12-01-100000
+     合計: 120.70 MB (4 スキーマ)
+     - core: 43.10 MB
+     - hr: 31.20 MB
+     - ops: 27.50 MB
+     - analytics: 18.90 MB
+
+💡 ヒント: 古いバックアップフォルダは手動で削除してください
+```
+
+### 推奨スケジュール
+
+月2回のバックアップを推奨します：
+- **毎月1日** と **15日**
+- カレンダーにリマインダーを設定
+
+---
+
+### バックアップのリストア方法
+
+dmpファイルから特定のスキーマをリストアする場合：
+
+```bash
+# 特定のバックアップフォルダを指定
+BACKUP_FOLDER="2025-12-22-120530"
+
+# 特定のスキーマをリストア（例: core スキーマ）
+pg_restore -d "postgresql://user:password@host:port/database" \
+  -n core \
+  --clean \
+  backups/${BACKUP_FOLDER}/core.dmp
+
+# または、全スキーマを一括でリストア
+pg_restore -d "postgresql://user:password@host:port/database" \
+  --clean \
+  backups/${BACKUP_FOLDER}/core.dmp
+
+pg_restore -d "postgresql://user:password@host:port/database" \
+  --clean \
+  backups/${BACKUP_FOLDER}/hr.dmp
+
+pg_restore -d "postgresql://user:password@host:port/database" \
+  --clean \
+  backups/${BACKUP_FOLDER}/ops.dmp
+
+pg_restore -d "postgresql://user:password@host:port/database" \
+  --clean \
+  backups/${BACKUP_FOLDER}/analytics.dmp
+```
+
+**全スキーマを一括でリストアするスクリプト例:**
+
+```bash
+#!/bin/bash
+BACKUP_FOLDER="2025-12-22-120530"
+DATABASE_URL="postgresql://user:password@host:port/database"
+
+for schema in core hr ops analytics; do
+  echo "リストア中: ${schema}"
+  pg_restore -d "${DATABASE_URL}" --clean backups/${BACKUP_FOLDER}/${schema}.dmp
+done
+```
+
+**オプション説明:**
+- `-d`: 接続先データベースURL
+- `-n`: リストアするスキーマ名
+- `--clean`: リストア前に既存のオブジェクトを削除
+
+⚠️ **注意**: `--clean` オプションは既存データを削除するため、本番環境での使用は十分注意してください。
+
+---
+
+## Phase 2: SharePoint自動アップロード（将来）
+
+**目的:** GitHub Actionsで自動実行し、SharePointに保存
+
+### 実装内容
+
+1. **GitHub Actionsで自動実行**
+   - スケジュール: 毎月1日と15日の午前3時（JST）
+   - 手動実行も可能
+
+2. **SharePointに自動アップロード**
+   - Microsoft Graph APIを使用
+   - Azure AD認証
+
+3. **通知機能**
+   - 成功時: Slackまたはメール通知（オプション）
+   - 失敗時: アラート通知
+
+### 必要な準備（承認後に実施）
+
+#### 1. Azure ADアプリケーションの登録
+
+1. **Azure Portalにアクセス**
+   - https://portal.azure.com
+
+2. **アプリケーションを登録**
+   - 「Azure Active Directory」→「アプリの登録」→「新規登録」
+   - 名前: `GitHub-DB-Backup-to-SharePoint`
+   - 「登録」をクリック
+
+3. **認証情報を取得**
+   - アプリケーション (クライアント) ID
+   - ディレクトリ (テナント) ID
+   - クライアントシークレット（「証明書とシークレット」で作成）
+
+4. **SharePointへのアクセス許可を付与**
+   - 「APIのアクセス許可」→「アクセス許可の追加」
+   - 「Microsoft Graph」→「アプリケーションの許可」
+   - 以下を追加:
+     - `Sites.ReadWrite.All`
+     - `Files.ReadWrite.All`
+   - 「管理者の同意を付与」をクリック
+
+#### 2. GitHub Secretsの設定
+
+GitHubリポジトリの Settings → Secrets and variables → Actions で以下を追加：
+
+| Secret名 | 説明 | 例 |
+|---------|------|-----|
+| `DATABASE_URL_PRODUCTION` | 本番DBのURL | `postgresql://user:pass@host:5432/db` |
+| `AZURE_TENANT_ID` | Azure ADテナントID | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` |
+| `AZURE_CLIENT_ID` | Azure ADクライアントID | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` |
+| `AZURE_CLIENT_SECRET` | Azure ADクライアントシークレット | `xxxxxxxxxxxxxxxxxxxxx` |
+| `SHAREPOINT_SITE_URL` | SharePointサイトURL | `https://company.sharepoint.com/sites/backups` |
+| `SHAREPOINT_FOLDER_PATH` | 保存先フォルダパス | `Shared Documents/DB-Backups` |
+
+#### 3. ワークフローファイルの有効化
+
+`.github/workflows/db-backup-to-sharepoint.yml` のコメントアウトを解除して有効化します。
+
+---
+
+## 移行手順
+
+### Phase 1 → Phase 2 への移行（SharePoint承認後）
+
+#### ステップ1: Azure AD設定（15分）
+1. Azure ADアプリケーションを登録
+2. SharePointへのアクセス許可を付与
+3. 認証情報（テナントID、クライアントID、シークレット）を取得
+
+#### ステップ2: GitHub Secrets設定（5分）
+1. GitHubリポジトリの Settings を開く
+2. Secrets and variables → Actions
+3. 上記6つのSecretを追加
+
+#### ステップ3: SharePointフォルダ作成（5分）
+1. SharePointサイトにアクセス
+2. バックアップ用フォルダを作成（例: `DB-Backups`）
+3. フォルダパスをメモ
+
+#### ステップ4: ワークフロー有効化（2分）
+1. `.github/workflows/db-backup-to-sharepoint.yml` を編集
+2. ファイル先頭の無効化コメントを削除
+3. コミット & プッシュ
+
+#### ステップ5: テスト実行（5分）
+1. GitHubの Actions タブを開く
+2. 「Database Backup to SharePoint」を選択
+3. 「Run workflow」で手動実行
+4. 実行ログを確認
+5. SharePointにファイルがアップロードされたか確認
+
+**所要時間: 約30分**
+
+---
+
+## トラブルシューティング
+
+### エラー: `pg_dump: command not found`
+
+**原因:** PostgreSQLクライアントがインストールされていない
+
+**解決策:**
+```bash
+# macOS
+brew install postgresql
+
+# Ubuntu/Debian
+sudo apt-get install postgresql-client
+```
+
+---
+
+### エラー: `DATABASE_URL が設定されていません`
+
+**原因:** 環境変数が設定されていない、または間違った場所に設定している
+
+**解決策:**
+
+1. **プロジェクトルートの `.env` ファイル**に `DATABASE_URL_PRODUCTION` を追加
+
+   ```bash
+   # shift-scheduler-ai/.env（プロジェクトルート）
+   DATABASE_URL_PRODUCTION=postgresql://user:password@host:port/database
+   ```
+
+2. ファイルの場所を確認：
+   ```bash
+   # プロジェクトルートにいることを確認
+   ls -la .env
+
+   # .envファイルが存在しない場合は作成
+   touch .env
+   ```
+
+3. または、コマンド実行時に環境変数を指定：
+   ```bash
+   DATABASE_URL_PRODUCTION="postgresql://..." npm run bk:prod
+   ```
+
+⚠️ **よくある間違い**: `backend/.env` や `frontend/.env` に設定しても読み込まれません。必ず**プロジェクトルートの `.env`** に設定してください。
+
+---
+
+### バックアップファイルが大きすぎる
+
+**原因:** データベースのサイズが大きい
+
+**解決策:**
+- 圧縮してから保存:
+  ```bash
+  # スクリプトを修正して gzip で圧縮
+  pg_dump "${DATABASE_URL}" | gzip > "${BACKUP_FILE}.gz"
+  ```
+- 古いデータを定期的にアーカイブ
+
+---
+
+### SharePointアップロードが失敗する（Phase 2）
+
+**原因1:** Azure ADの権限が不足
+
+**解決策:**
+- Azure Portalで `Sites.ReadWrite.All` と `Files.ReadWrite.All` が付与されているか確認
+- 管理者の同意が付与されているか確認
+
+**原因2:** GitHub Secretsの設定ミス
+
+**解決策:**
+- 各Secretの値を再確認
+- 特に `AZURE_CLIENT_SECRET` は表示されないので注意
+
+---
+
+## セキュリティ上の注意
+
+1. **`.env` ファイルをGitにコミットしない**
+   - すでに `.gitignore` に追加済み
+   - 本番DBのURLが含まれるため特に注意
+
+2. **バックアップファイルをGitにコミットしない**
+   - `backups/` ディレクトリは `.gitignore` に追加済み
+   - バックアップファイルには本番データが含まれるため特に注意
+
+3. **本番DBのURLは厳重に管理**
+   - 他人と共有しない
+   - ローカルマシンのセキュリティを確保
+   - 必要なメンバーのみがアクセスできるようにする
+
+4. **古いバックアップフォルダの削除**
+   - 定期的にローカルの古いバックアップフォルダを削除
+   - ディスク容量とセキュリティの観点から重要
+   - 最低3ヶ月分のみ保持することを推奨
+
+   ```bash
+   # 古いバックアップフォルダを削除する例
+   rm -rf backups/2024-10-*
+
+   # または、特定の日付以前を削除
+   find backups/ -type d -name "2024-*" -exec rm -rf {} +
+   ```
+
+---
+
+## よくある質問
+
+### Q: バックアップの頻度はどのくらいが適切？
+
+A: 本番環境のデータの重要度と更新頻度によりますが、**月2回（1日と15日）**を推奨します。より頻繁なバックアップが必要な場合は、Phase 2移行後にスケジュールを調整できます。
+
+### Q: バックアップフォルダが増えてディスク容量を圧迫する場合は？
+
+A: 古いバックアップフォルダを定期的に削除してください。3ヶ月以上前のバックアップは削除しても問題ないケースが多いです。
+
+```bash
+# 3ヶ月以上前のバックアップフォルダを削除（例）
+# 注意: 実行前に内容を確認してください
+ls -la backups/
+rm -rf backups/2024-09-*
+```
+
+### Q: バックアップフォルダはどのくらい保存すべき？
+
+A: **最低3ヶ月分**を保存することを推奨します。Phase 2では、SharePointに長期保存し、ローカルは最新1-2個のみ保持するのが良いでしょう。
+
+### Q: 特定のスキーマだけバックアップできる？
+
+A: 現在は4つのスキーマ（core, hr, ops, analytics）すべてをバックアップする設計です。特定のスキーマのみが必要な場合は、`scripts/backup/backup-db.mjs` の `SCHEMAS` 配列を編集してください。
+
+```javascript
+// バックアップ対象のスキーマ（カスタマイズ可能）
+const SCHEMAS = ['core', 'hr']; // 例: coreとhrのみ
+```
+
+### Q: Phase 1とPhase 2を併用できる？
+
+A: はい、可能です。Phase 2移行後も、念のためローカルバックアップを取得することをお勧めします（冗長性の確保）。
+
+### Q: 他のストレージ（S3、Azure Blob Storage）への移行は？
+
+A: 設計上、簡単に移行可能です。詳細は開発チームにお問い合わせください。
+
+---
+
+## 関連ファイル
+
+- `scripts/backup/backup-db.mjs` - バックアップスクリプト本体
+- `.github/workflows/db-backup-to-sharepoint.yml` - GitHub Actionsワークフロー（Phase 2）
+- `scripts/backup/upload-to-sharepoint.mjs` - SharePointアップロードスクリプト（Phase 2）
+
+---
+
+## サポート
+
+質問や問題がある場合は、開発チームまでお問い合わせください。

--- a/scripts/backup/backup-db.mjs
+++ b/scripts/backup/backup-db.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+
+/**
+ * データベースバックアップスクリプト
+ *
+ * Phase 1: ローカル手動実行用（現在の実装）
+ * - 本番DBからバックアップを取得してローカルに保存
+ *
+ * Phase 2: SharePoint自動アップロード対応（将来実装予定）
+ * - GitHub Actionsで自動実行
+ * - SharePointへの自動アップロード
+ */
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+
+const execAsync = promisify(exec);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.join(__dirname, '../..');
+
+// プロジェクトルートの.envファイルを読み込む
+dotenv.config({ path: path.join(rootDir, '.env') });
+
+// 設定
+const BACKUP_ROOT_DIR = path.join(__dirname, '../../backups');
+const now = new Date();
+const TIMESTAMP = now.toISOString()
+  .replace(/T/, '-')
+  .replace(/:/g, '')
+  .replace(/\..+/, '')
+  .slice(0, 15); // YYYY-MM-DD-HHMMSS 形式
+const BACKUP_DIR = path.join(BACKUP_ROOT_DIR, TIMESTAMP);
+
+// 環境変数からデータベースURLを取得
+const DATABASE_URL = process.env.DATABASE_URL_PRODUCTION || process.env.DATABASE_URL;
+
+// バックアップ対象のスキーマ
+const SCHEMAS = ['core', 'hr', 'ops', 'analytics'];
+
+/**
+ * 各スキーマのバックアップを作成
+ */
+async function backupSchema(schema) {
+  const backupFile = path.join(BACKUP_DIR, `${schema}.dmp`);
+
+  console.log(`💾 スキーマ「${schema}」をバックアップ中...`);
+
+  try {
+    // pg_dump で dmp 形式（カスタムフォーマット）でバックアップを作成
+    const { stdout, stderr } = await execAsync(
+      `pg_dump -Fc -n ${schema} "${DATABASE_URL}" -f "${backupFile}"`,
+      { maxBuffer: 1024 * 1024 * 100 } // 100MB buffer
+    );
+
+    if (stderr && !stderr.includes('WARNING')) {
+      console.warn(`⚠️  警告 (${schema}):`, stderr);
+    }
+
+    // ファイルサイズを確認
+    const stats = fs.statSync(backupFile);
+    const fileSizeMB = (stats.size / (1024 * 1024)).toFixed(2);
+
+    console.log(`✅ ${schema}: ${fileSizeMB} MB`);
+
+    return { schema, success: true, file: backupFile, size: fileSizeMB };
+
+  } catch (error) {
+    console.error(`❌ ${schema}: バックアップに失敗しました -`, error.message);
+    return { schema, success: false, error: error.message };
+  }
+}
+
+/**
+ * データベースのバックアップを作成
+ */
+async function createBackup() {
+  console.log('🚀 データベースバックアップを開始します...');
+  console.log(`📅 日時: ${now.toLocaleString('ja-JP')}`);
+  console.log(`📋 対象スキーマ: ${SCHEMAS.join(', ')}`);
+  console.log(`📂 保存フォルダ: ${TIMESTAMP}`);
+  console.log('');
+
+  // DATABASE_URLのチェック
+  if (!DATABASE_URL) {
+    console.error('❌ エラー: DATABASE_URL または DATABASE_URL_PRODUCTION が設定されていません');
+    console.error('');
+    console.error('以下のいずれかの方法で設定してください：');
+    console.error('1. プロジェクトルートの .env ファイルに DATABASE_URL_PRODUCTION を追加');
+    console.error('2. コマンド実行時に環境変数を指定:');
+    console.error('   DATABASE_URL_PRODUCTION="postgresql://..." npm run bk:prod');
+    process.exit(1);
+  }
+
+  // バックアップディレクトリの作成（タイムスタンプごとのフォルダ）
+  if (!fs.existsSync(BACKUP_DIR)) {
+    console.log(`📁 バックアップディレクトリを作成: ${BACKUP_DIR}`);
+    fs.mkdirSync(BACKUP_DIR, { recursive: true });
+  }
+
+  try {
+    // 各スキーマを順番にバックアップ
+    const results = [];
+
+    for (const schema of SCHEMAS) {
+      const result = await backupSchema(schema);
+      results.push(result);
+    }
+
+    console.log('');
+    console.log('📊 バックアップ結果サマリー:');
+    console.log('');
+
+    const successful = results.filter(r => r.success);
+    const failed = results.filter(r => !r.success);
+
+    if (successful.length > 0) {
+      console.log(`✅ 成功: ${successful.length}/${SCHEMAS.length} スキーマ`);
+      successful.forEach(r => {
+        console.log(`   - ${r.schema}: ${r.size} MB`);
+      });
+    }
+
+    if (failed.length > 0) {
+      console.log('');
+      console.log(`❌ 失敗: ${failed.length}/${SCHEMAS.length} スキーマ`);
+      failed.forEach(r => {
+        console.log(`   - ${r.schema}: ${r.error}`);
+      });
+    }
+
+    console.log('');
+    console.log(`📍 保存場所: ${BACKUP_DIR}`);
+    console.log('');
+
+    // 古いバックアップファイルを確認
+    listBackups();
+
+    // 失敗があった場合はエラー終了
+    if (failed.length > 0) {
+      process.exit(1);
+    }
+
+  } catch (error) {
+    console.error('❌ バックアップ中にエラーが発生しました:', error.message);
+
+    // エラーの詳細を表示
+    if (error.message.includes('pg_dump')) {
+      console.error('');
+      console.error('💡 pg_dump がインストールされていない可能性があります。');
+      console.error('以下のコマンドでインストールしてください：');
+      console.error('  macOS: brew install postgresql');
+      console.error('  Ubuntu: sudo apt-get install postgresql-client');
+      console.error('  Windows: https://www.postgresql.org/download/windows/');
+    }
+
+    process.exit(1);
+  }
+}
+
+/**
+ * 既存のバックアップフォルダ一覧を表示
+ */
+function listBackups() {
+  if (!fs.existsSync(BACKUP_ROOT_DIR)) {
+    return;
+  }
+
+  // バックアップフォルダを取得（タイムスタンプ形式のフォルダのみ）
+  const folders = fs.readdirSync(BACKUP_ROOT_DIR)
+    .filter(item => {
+      const fullPath = path.join(BACKUP_ROOT_DIR, item);
+      return fs.statSync(fullPath).isDirectory() && /^\d{4}-\d{2}-\d{2}-\d{6}$/.test(item);
+    })
+    .sort()
+    .reverse();
+
+  if (folders.length > 0) {
+    console.log('📋 既存のバックアップ:');
+    console.log('');
+
+    folders.forEach((folder, index) => {
+      const isLatest = index === 0;
+      const folderPath = path.join(BACKUP_ROOT_DIR, folder);
+
+      // フォルダ内のdmpファイルを取得
+      const files = fs.existsSync(folderPath)
+        ? fs.readdirSync(folderPath).filter(file => file.endsWith('.dmp'))
+        : [];
+
+      // 合計サイズを計算
+      let totalSize = 0;
+      const schemaInfo = [];
+
+      files.forEach(file => {
+        const filePath = path.join(folderPath, file);
+        if (fs.existsSync(filePath)) {
+          const stats = fs.statSync(filePath);
+          const fileSizeMB = stats.size / (1024 * 1024);
+          totalSize += fileSizeMB;
+
+          const schema = file.replace('.dmp', '');
+          schemaInfo.push({ schema, size: fileSizeMB.toFixed(2) });
+        }
+      });
+
+      console.log(`  ${isLatest ? '✨' : '  '} ${folder}${isLatest ? ' [最新]' : ''}`);
+      console.log(`     合計: ${totalSize.toFixed(2)} MB (${files.length} スキーマ)`);
+
+      schemaInfo.forEach(info => {
+        console.log(`     - ${info.schema}: ${info.size} MB`);
+      });
+
+      console.log('');
+    });
+
+    console.log(`💡 ヒント: 古いバックアップフォルダは手動で削除してください (${BACKUP_ROOT_DIR})`);
+  }
+}
+
+// スクリプト実行
+createBackup();

--- a/scripts/backup/upload-to-sharepoint.mjs
+++ b/scripts/backup/upload-to-sharepoint.mjs
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+
+/**
+ * SharePointアップロードスクリプト
+ *
+ * Microsoft Graph APIを使用してSharePointにバックアップファイルをアップロード
+ *
+ * 環境変数:
+ *   - AZURE_TENANT_ID: Azure ADテナントID
+ *   - AZURE_CLIENT_ID: Azure ADクライアントID
+ *   - AZURE_CLIENT_SECRET: Azure ADクライアントシークレット
+ *   - SHAREPOINT_SITE_URL: SharePointサイトURL
+ *   - SHAREPOINT_FOLDER_PATH: 保存先フォルダパス
+ *   - BACKUP_FILE: アップロードするファイル名
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// 環境変数の取得
+const AZURE_TENANT_ID = process.env.AZURE_TENANT_ID;
+const AZURE_CLIENT_ID = process.env.AZURE_CLIENT_ID;
+const AZURE_CLIENT_SECRET = process.env.AZURE_CLIENT_SECRET;
+const SHAREPOINT_SITE_URL = process.env.SHAREPOINT_SITE_URL;
+const SHAREPOINT_FOLDER_PATH = process.env.SHAREPOINT_FOLDER_PATH || 'Shared Documents/DB-Backups';
+const BACKUP_FILE = process.env.BACKUP_FILE;
+
+/**
+ * 環境変数のチェック
+ */
+function validateEnvironmentVariables() {
+  const required = {
+    AZURE_TENANT_ID,
+    AZURE_CLIENT_ID,
+    AZURE_CLIENT_SECRET,
+    SHAREPOINT_SITE_URL,
+    BACKUP_FILE,
+  };
+
+  const missing = Object.entries(required)
+    .filter(([key, value]) => !value)
+    .map(([key]) => key);
+
+  if (missing.length > 0) {
+    console.error('❌ エラー: 以下の環境変数が設定されていません:');
+    missing.forEach(key => console.error(`  - ${key}`));
+    console.error('');
+    console.error('詳細は scripts/backup/README.md を参照してください。');
+    process.exit(1);
+  }
+}
+
+/**
+ * Azure ADアクセストークンを取得
+ */
+async function getAccessToken() {
+  console.log('🔑 Azure ADアクセストークンを取得中...');
+
+  const tokenEndpoint = `https://login.microsoftonline.com/${AZURE_TENANT_ID}/oauth2/v2.0/token`;
+
+  const params = new URLSearchParams({
+    client_id: AZURE_CLIENT_ID,
+    client_secret: AZURE_CLIENT_SECRET,
+    scope: 'https://graph.microsoft.com/.default',
+    grant_type: 'client_credentials',
+  });
+
+  try {
+    const response = await fetch(tokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: params,
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`認証エラー: ${response.status} ${error}`);
+    }
+
+    const data = await response.json();
+    console.log('✅ アクセストークン取得成功');
+    return data.access_token;
+
+  } catch (error) {
+    console.error('❌ アクセストークン取得エラー:', error.message);
+    throw error;
+  }
+}
+
+/**
+ * SharePointサイトIDを取得
+ */
+async function getSiteId(accessToken) {
+  console.log('🔍 SharePointサイトIDを取得中...');
+
+  try {
+    // URLからホスト名とサイトパスを抽出
+    const siteUrl = new URL(SHAREPOINT_SITE_URL);
+    const hostname = siteUrl.hostname;
+    const sitePath = siteUrl.pathname;
+
+    const endpoint = `https://graph.microsoft.com/v1.0/sites/${hostname}:${sitePath}`;
+
+    const response = await fetch(endpoint, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`サイトID取得エラー: ${response.status} ${error}`);
+    }
+
+    const data = await response.json();
+    console.log('✅ サイトID取得成功');
+    return data.id;
+
+  } catch (error) {
+    console.error('❌ サイトID取得エラー:', error.message);
+    throw error;
+  }
+}
+
+/**
+ * SharePointにファイルをアップロード
+ */
+async function uploadToSharePoint(accessToken, siteId, filePath) {
+  console.log('📤 SharePointにアップロード中...');
+
+  try {
+    const fileName = path.basename(filePath);
+    const fileContent = fs.readFileSync(filePath);
+    const fileSize = fileContent.length;
+
+    console.log(`📂 ファイル名: ${fileName}`);
+    console.log(`📊 ファイルサイズ: ${(fileSize / (1024 * 1024)).toFixed(2)} MB`);
+
+    // ファイルサイズが4MB未満の場合は単純アップロード
+    if (fileSize < 4 * 1024 * 1024) {
+      return await simpleUpload(accessToken, siteId, fileName, fileContent);
+    } else {
+      // 4MB以上の場合はアップロードセッションを使用
+      return await largeFileUpload(accessToken, siteId, fileName, fileContent);
+    }
+
+  } catch (error) {
+    console.error('❌ アップロードエラー:', error.message);
+    throw error;
+  }
+}
+
+/**
+ * 単純アップロード（4MB未満）
+ */
+async function simpleUpload(accessToken, siteId, fileName, fileContent) {
+  const endpoint = `https://graph.microsoft.com/v1.0/sites/${siteId}/drive/root:/${SHAREPOINT_FOLDER_PATH}/${fileName}:/content`;
+
+  const response = await fetch(endpoint, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/octet-stream',
+    },
+    body: fileContent,
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`アップロードエラー: ${response.status} ${error}`);
+  }
+
+  const data = await response.json();
+  console.log('✅ アップロード成功');
+  console.log(`🔗 SharePointリンク: ${data.webUrl}`);
+
+  return data;
+}
+
+/**
+ * 大容量ファイルのアップロード（4MB以上）
+ */
+async function largeFileUpload(accessToken, siteId, fileName, fileContent) {
+  console.log('📦 大容量ファイルのアップロード処理を開始...');
+
+  // アップロードセッションを作成
+  const createSessionEndpoint = `https://graph.microsoft.com/v1.0/sites/${siteId}/drive/root:/${SHAREPOINT_FOLDER_PATH}/${fileName}:/createUploadSession`;
+
+  const sessionResponse = await fetch(createSessionEndpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      item: {
+        '@microsoft.graph.conflictBehavior': 'replace',
+      },
+    }),
+  });
+
+  if (!sessionResponse.ok) {
+    const error = await sessionResponse.text();
+    throw new Error(`セッション作成エラー: ${sessionResponse.status} ${error}`);
+  }
+
+  const sessionData = await sessionResponse.json();
+  const uploadUrl = sessionData.uploadUrl;
+
+  // チャンクサイズ（320KB推奨）
+  const chunkSize = 320 * 1024;
+  const fileSize = fileContent.length;
+  let offset = 0;
+
+  while (offset < fileSize) {
+    const chunkEnd = Math.min(offset + chunkSize, fileSize);
+    const chunk = fileContent.slice(offset, chunkEnd);
+
+    console.log(`📤 アップロード進捗: ${((chunkEnd / fileSize) * 100).toFixed(1)}%`);
+
+    const chunkResponse = await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: {
+        'Content-Length': chunk.length.toString(),
+        'Content-Range': `bytes ${offset}-${chunkEnd - 1}/${fileSize}`,
+      },
+      body: chunk,
+    });
+
+    if (!chunkResponse.ok && chunkResponse.status !== 202) {
+      const error = await chunkResponse.text();
+      throw new Error(`チャンクアップロードエラー: ${chunkResponse.status} ${error}`);
+    }
+
+    offset = chunkEnd;
+  }
+
+  console.log('✅ アップロード成功');
+  return { success: true };
+}
+
+/**
+ * メイン処理
+ */
+async function main() {
+  console.log('🚀 SharePointアップロード処理を開始します...');
+  console.log(`📅 日時: ${new Date().toLocaleString('ja-JP')}`);
+  console.log('');
+
+  try {
+    // 環境変数のチェック
+    validateEnvironmentVariables();
+
+    // バックアップファイルの存在確認
+    if (!fs.existsSync(BACKUP_FILE)) {
+      throw new Error(`バックアップファイルが見つかりません: ${BACKUP_FILE}`);
+    }
+
+    // アクセストークン取得
+    const accessToken = await getAccessToken();
+
+    // サイトID取得
+    const siteId = await getSiteId(accessToken);
+
+    // ファイルアップロード
+    await uploadToSharePoint(accessToken, siteId, BACKUP_FILE);
+
+    console.log('');
+    console.log('✅ すべての処理が正常に完了しました！');
+
+  } catch (error) {
+    console.error('');
+    console.error('❌ エラーが発生しました:', error.message);
+    console.error('');
+    console.error('💡 トラブルシューティング:');
+    console.error('  1. Azure ADの権限設定を確認してください');
+    console.error('  2. SharePointサイトURLが正しいか確認してください');
+    console.error('  3. フォルダパスが存在するか確認してください');
+    console.error('');
+    console.error('詳細は scripts/backup/README.md を参照してください。');
+    process.exit(1);
+  }
+}
+
+// スクリプト実行
+main();


### PR DESCRIPTION
月2回（1日と15日）のデータベースバックアップを実現するための機能を実装

## 追加機能
- スキーマごと（core, hr, ops, analytics）のdmpファイル生成
- タイムスタンプごとのフォルダで整理
- PostgreSQL 17対応のpg_dumpコマンド使用
- npm run bk:prod でローカル実行可能

## Phase 2準備（将来実装）
- SharePoint自動アップロード用のGitHub Actionsワークフロー
- Microsoft Graph API連携スクリプト

## 変更内容
- scripts/backup/backup-db.mjs: バックアップスクリプト本体
- scripts/backup/README.md: 詳細な使用方法とトラブルシューティング
- scripts/backup/upload-to-sharepoint.mjs: SharePointアップロード機能（Phase 2用）
- .github/workflows/db-backup-to-sharepoint.yml: 自動実行ワークフロー（Phase 2用、現在無効）
- package.json: bk:prod コマンドを追加
- .gitignore: バックアップファイル（*.dmp）を除外

🤖 Generated with [Claude Code](https://claude.com/claude-code)