### PR TITLE
fix: 提出状況判定をstaff_monthly_submissionsテーブルベースに変更

### DIFF
--- a/frontend/src/components/screens/shift/Monitoring.jsx
+++ b/frontend/src/components/screens/shift/Monitoring.jsx
@@ -173,20 +173,27 @@ const Monitoring = () => {
         ? `${apiUrl}/api/shifts/submissions?tenant_id=${tenantId}&year=${historyYear}&month=${historyMonth}`
         : null
 
-      const [staffResponse, rolesResponse, patternsResponse, preferencesResponse, submissionsResponse] =
-        await Promise.all([
-          fetch(`${apiUrl}/api/master/staff?tenant_id=${tenantId}`),
-          fetch(`${apiUrl}/api/master/roles?tenant_id=${tenantId}`),
-          fetch(`${apiUrl}/api/master/shift-patterns?tenant_id=${tenantId}`),
-          fetch(preferencesUrl),
-          submissionsUrl ? fetch(submissionsUrl) : Promise.resolve(null),
-        ])
+      const [
+        staffResponse,
+        rolesResponse,
+        patternsResponse,
+        preferencesResponse,
+        submissionsResponse,
+      ] = await Promise.all([
+        fetch(`${apiUrl}/api/master/staff?tenant_id=${tenantId}`),
+        fetch(`${apiUrl}/api/master/roles?tenant_id=${tenantId}`),
+        fetch(`${apiUrl}/api/master/shift-patterns?tenant_id=${tenantId}`),
+        fetch(preferencesUrl),
+        submissionsUrl ? fetch(submissionsUrl) : Promise.resolve(null),
+      ])
 
       const staffResult = await staffResponse.json()
       const rolesResult = await rolesResponse.json()
       const patternsResult = await patternsResponse.json()
       const preferencesResult = await preferencesResponse.json()
-      const submissionsResult = submissionsResponse ? await submissionsResponse.json() : { success: true, data: [] }
+      const submissionsResult = submissionsResponse
+        ? await submissionsResponse.json()
+        : { success: true, data: [] }
 
       const staffData = staffResult.success ? staffResult.data : []
       const rolesData = rolesResult.success ? rolesResult.data : []

--- a/frontend/src/components/screens/shift/Monitoring.jsx
+++ b/frontend/src/components/screens/shift/Monitoring.jsx
@@ -168,24 +168,31 @@ const Monitoring = () => {
         dateTo = `${historyYear}-12-31`
       }
       const preferencesUrl = `${apiUrl}/api/shifts/preferences?tenant_id=${tenantId}&date_from=${dateFrom}&date_to=${dateTo}`
+      // 提出状況取得用URL（月が指定されている場合のみ）
+      const submissionsUrl = historyMonth
+        ? `${apiUrl}/api/shifts/submissions?tenant_id=${tenantId}&year=${historyYear}&month=${historyMonth}`
+        : null
 
-      const [staffResponse, rolesResponse, patternsResponse, preferencesResponse] =
+      const [staffResponse, rolesResponse, patternsResponse, preferencesResponse, submissionsResponse] =
         await Promise.all([
           fetch(`${apiUrl}/api/master/staff?tenant_id=${tenantId}`),
           fetch(`${apiUrl}/api/master/roles?tenant_id=${tenantId}`),
           fetch(`${apiUrl}/api/master/shift-patterns?tenant_id=${tenantId}`),
           fetch(preferencesUrl),
+          submissionsUrl ? fetch(submissionsUrl) : Promise.resolve(null),
         ])
 
       const staffResult = await staffResponse.json()
       const rolesResult = await rolesResponse.json()
       const patternsResult = await patternsResponse.json()
       const preferencesResult = await preferencesResponse.json()
+      const submissionsResult = submissionsResponse ? await submissionsResponse.json() : { success: true, data: [] }
 
       const staffData = staffResult.success ? staffResult.data : []
       const rolesData = rolesResult.success ? rolesResult.data : []
       const patternsData = patternsResult.success ? patternsResult.data : []
       let availData = preferencesResult.success ? preferencesResult.data : []
+      const submissionsData = submissionsResult.success ? submissionsResult.data : []
 
       // スタッフマップと役職マップを作成
       const staffMapping = {}
@@ -251,33 +258,20 @@ const Monitoring = () => {
         }
       })
 
-      // ★変更: 新API形式（1日1レコード）での提出状況集計
+      // staff_monthly_submissionsテーブルのレコード有無で提出状況を判定
       // created_atまたはupdated_atを提出日時として使用
       const submittedStaffIds = new Set()
-      availData.forEach(req => {
-        // 1日1レコード形式なので、レコードがあれば提出済み
-        const submittedAt = req.updated_at || req.created_at
-        if (submittedAt) {
-          submittedStaffIds.add(req.staff_id.toString())
+      submissionsData.forEach(submission => {
+        // staff_monthly_submissionsにレコードがあれば提出済み
+        const submittedAt = submission.updated_at || submission.created_at
+        submittedStaffIds.add(submission.staff_id.toString())
 
-          if (staffMap[req.staff_id]) {
-            const date = new Date(submittedAt)
-            const formatted = `${date.getMonth() + 1}/${date.getDate()} ${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')}`
-            if (
-              !staffMap[req.staff_id].submittedAt ||
-              new Date(submittedAt) > new Date(staffMap[req.staff_id].rawSubmittedAt || 0)
-            ) {
-              staffMap[req.staff_id].submittedAt = formatted
-              staffMap[req.staff_id].rawSubmittedAt = submittedAt
-            }
-          }
-        }
-      })
-
-      // 提出済みフラグを設定
-      Object.keys(staffMap).forEach(staffId => {
-        if (submittedStaffIds.has(staffId)) {
-          staffMap[staffId].submitted = true
+        if (staffMap[submission.staff_id]) {
+          const date = new Date(submittedAt)
+          const formatted = `${date.getMonth() + 1}/${date.getDate()} ${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')}`
+          staffMap[submission.staff_id].submittedAt = formatted
+          staffMap[submission.staff_id].rawSubmittedAt = submittedAt
+          staffMap[submission.staff_id].submitted = true
         }
       })
 

--- a/frontend/src/infrastructure/repositories/ShiftRepository.js
+++ b/frontend/src/infrastructure/repositories/ShiftRepository.js
@@ -696,6 +696,54 @@ export class ShiftRepository {
   }
 
   /**
+   * シフト提出状況一覧を取得
+   * staff_monthly_submissionsテーブルのレコード有無で提出済み/未提出を判定
+   * @param {Object} filters - フィルタリング条件
+   * @param {number} filters.tenantId - テナントID
+   * @param {number} filters.year - 年 (required)
+   * @param {number} filters.month - 月 (required)
+   * @param {number} filters.storeId - 店舗ID (オプション)
+   * @returns {Promise<Array>} 提出状況データ配列
+   */
+  async getSubmissions(filters = {}) {
+    try {
+      const { tenantId = null, year, month, storeId } = filters
+
+      const actualTenantId = tenantId ?? getCurrentTenantId()
+
+      if (!year || !month) {
+        throw new Error('Year and month parameters are required')
+      }
+
+      const params = new URLSearchParams({
+        tenant_id: actualTenantId,
+        year,
+        month,
+      })
+      if (storeId) params.append('store_id', storeId)
+
+      const url = `${BACKEND_API_URL}/api/shifts/submissions?${params}`
+      const response = await fetch(url)
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+
+      const result = await response.json()
+
+      if (!result.success) {
+        throw new Error(result.error || '提出状況取得に失敗しました')
+      }
+
+      return result.data
+    } catch (error) {
+      console.error('提出状況取得エラー:', error)
+      // 提出状況取得失敗時は空配列を返す
+      return []
+    }
+  }
+
+  /**
    * シフト希望入力締切設定を取得
    * @param {number} tenantId - テナントID
    * @returns {Promise<Array>} 締切設定データ配列


### PR DESCRIPTION
## Summary
- 管理画面のシフト提出状況判定ロジックをshift_preferencesからstaff_monthly_submissionsテーブルに変更
- LIFFバックエンドと同じテーブルを参照することで一貫性を確保

## Changes
- backend: GET /api/shifts/submissions エンドポイント追加
- frontend: ShiftRepository.getSubmissions() メソッド追加
- frontend: useShiftStatus.js の提出判定ロジック変更
- frontend: Monitoring.jsx の提出状況集計ロジック変更

## Test plan
- [x] 管理画面でシフト希望提出状況画面を開く
- [x] LIFFで提出済みのスタッフが「提出済み」と表示されることを確認
- [x] LIFFで未提出のスタッフが「未提出」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)