### PR TITLE
fix: シフト保存の連打防止と重複チェック修正

### DIFF
--- a/frontend/src/hooks/useShiftPlanEditor.js
+++ b/frontend/src/hooks/useShiftPlanEditor.js
@@ -153,7 +153,7 @@ export const useShiftPlanEditor = ({
     })
 
     return {
-      hasOverlaps: overlaps.size > 0,
+      hasOverlap: overlaps.size > 0,
       overlappingShiftIds: overlaps,
     }
   }, [shiftData])


### PR DESCRIPTION
## Summary
- 時間重複チェックのプロパティ名を修正 (`hasOverlaps` → `hasOverlap`)
- アルバイト希望一括反映ボタンの連打防止を追加
- シフト保存時に削除を先に実行するよう修正

## Changes

### 1. プロパティ名修正 (useShiftPlanEditor.js)
- `hasOverlaps` → `hasOverlap` に修正
- SecondPlanEditorで参照しているプロパティ名に合わせた

### 2. 連打防止 (SecondPlanEditor.jsx)
- processing stateを追加
- 一括反映、削除、保存、承認ボタンにdisabled状態を追加

### 3. DELETE先実行 (useShiftEditing.js)
- DELETE → CREATE/UPDATE の順序に変更
- 一括反映後の保存時に発生する重複チェックエラーを解消

## Test plan
- [ ] 時間重複があるシフトを追加した場合、保存ボタンが無効化されることを確認
- [ ] アルバイト希望一括反映→下書き保存が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)