### PR TITLE
fix: 時間重複チェック機能の修正

### DIFF
--- a/frontend/src/hooks/useShiftPlanEditor.js
+++ b/frontend/src/hooks/useShiftPlanEditor.js
@@ -153,7 +153,7 @@ export const useShiftPlanEditor = ({
     })
 
     return {
-      hasOverlaps: overlaps.size > 0,
+      hasOverlap: overlaps.size > 0,
       overlappingShiftIds: overlaps,
     }
   }, [shiftData])

--- a/frontend/src/hooks/useShiftPlanEditor.js
+++ b/frontend/src/hooks/useShiftPlanEditor.js
@@ -138,14 +138,22 @@ export const useShiftPlanEditor = ({
     })
 
     // 重複を検出
-    const overlaps = new Set()
+    const overlappingShiftIds = new Set()
+    const overlaps = []
     Object.values(groupedByStaffDate).forEach(shifts => {
       if (shifts.length > 1) {
         for (let i = 0; i < shifts.length; i++) {
           for (let j = i + 1; j < shifts.length; j++) {
             if (isOverlap(shifts[i], shifts[j])) {
-              overlaps.add(shifts[i].shift_id)
-              overlaps.add(shifts[j].shift_id)
+              overlappingShiftIds.add(shifts[i].shift_id)
+              overlappingShiftIds.add(shifts[j].shift_id)
+              overlaps.push({
+                staffId: shifts[i].staff_id,
+                staffName: shifts[i].staff_name,
+                date: shifts[i].shift_date,
+                shift1: shifts[i],
+                shift2: shifts[j],
+              })
             }
           }
         }
@@ -153,8 +161,9 @@ export const useShiftPlanEditor = ({
     })
 
     return {
-      hasOverlap: overlaps.size > 0,
-      overlappingShiftIds: overlaps,
+      hasOverlap: overlaps.length > 0,
+      overlappingShiftIds,
+      overlaps,
     }
   }, [shiftData])
 


### PR DESCRIPTION
## Summary
- 時間重複チェックのプロパティ名を修正 (`hasOverlaps` → `hasOverlap`)
- シフト保存時に削除を先に実行するよう修正
- 時間重複チェックの`overlaps`配列を復元

## Changes

### 1. プロパティ名修正 (useShiftPlanEditor.js)
- `hasOverlaps` → `hasOverlap` に修正
- コンポーネントが期待するプロパティ名に合わせた

### 2. DELETE先実行 (useShiftEditing.js)
- DELETE → CREATE/UPDATE の順序に変更
- 一括反映後の保存時に発生しうる重複チェックエラーを防止

### 3. overlaps配列復元 (useShiftPlanEditor.js)
- リファクタリング時に失われた`overlaps`配列を復元
- FirstPlanEditor/SecondPlanEditorの詳細表示に必要なデータ構造を提供

## Test plan
- [x] 時間重複があるシフトを追加した場合、警告が表示されることを確認
- [x] ホバー時に重複詳細が表示されることを確認
- [ ] 保存・承認ボタンが無効化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)